### PR TITLE
Implement basic agent logic

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 from PyQt5 import QtWidgets, QtCore
+import random
 
 from agents.market_sentiment import MarketSentimentAgent
 from agents.strategy_selector import StrategySelector
@@ -21,6 +22,14 @@ class TradingApp(QtWidgets.QApplication):
         self.visualizer = VisualizerAgent()
         self.visualizer.show()
         self.timer = self.createTimer()
+        # demo state
+        self.candles = []
+        self.order_book = {"bid": 100.0, "ask": 100.0}
+        self.trade_strength = 0.5
+        self.last_price = 100.0
+        self.position = None
+        self.sentiment = "NEUTRAL"
+        self.strategy = ("hold", {})
 
     def createTimer(self):
         timer = QtCore.QTimer()
@@ -29,13 +38,40 @@ class TradingApp(QtWidgets.QApplication):
         return timer
 
     def loop(self):
-        # Placeholder example data
-        sentiment = self.sentiment_agent.update(None, None, None)
-        strategy, params = self.strategy_selector.select(sentiment)
-        signal = self.entry_agent.evaluate((strategy, params), None, None)
-        position = "None"
-        self.logger.log("EntryDecisionAgent", signal)
-        self.visualizer.update_state(sentiment, strategy, position)
+        self._generate_fake_data()
+        self.sentiment = self.sentiment_agent.update(
+            self.candles, self.order_book, self.trade_strength
+        )
+        self.strategy = self.strategy_selector.select(self.sentiment)
+        signal = self.entry_agent.evaluate(self.strategy, self.candles, None)
+
+        if signal in ("BUY", "SELL") and not self.position:
+            self.position = {"side": signal, "entry_price": self.last_price}
+            self.logger.log("EntryDecisionAgent", signal, price=self.last_price)
+
+        if self.position:
+            close_signal = self.position_manager.update(
+                self.position, self.position["entry_price"], self.last_price
+            )
+            if close_signal == "CLOSE":
+                self.logger.log("PositionManager", "CLOSE", price=self.last_price)
+                self.position = None
+
+        pos_text = self.position["side"] if self.position else "None"
+        self.visualizer.update_state(
+            self.sentiment, self.strategy[0], pos_text
+        )
+
+    def _generate_fake_data(self):
+        """Create example candle and order book data."""
+        self.last_price += random.uniform(-1, 1)
+        volume = random.uniform(80, 120)
+        self.order_book["bid"] = random.uniform(50, 150)
+        self.order_book["ask"] = random.uniform(50, 150)
+        self.trade_strength = random.random()
+        self.candles.append({"close": self.last_price, "volume": volume})
+        if len(self.candles) > 200:
+            self.candles.pop(0)
 
 
 if __name__ == "__main__":

--- a/src/agents/entry_decision.py
+++ b/src/agents/entry_decision.py
@@ -1,10 +1,62 @@
+"""Evaluate entry signals based on current strategy."""
+
+from __future__ import annotations
+
+from typing import Iterable, Mapping, Tuple
+
+
 class EntryDecisionAgent:
     """Determine trade entry signals."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         pass
 
-    def evaluate(self, strategy, chart_data, order_status):
+    @staticmethod
+    def _rsi(prices: Iterable[float], period: int = 14) -> float:
+        prices = list(prices)
+        if len(prices) <= period:
+            return 50.0
+        gains = []
+        losses = []
+        for i in range(1, period + 1):
+            diff = prices[-i] - prices[-i - 1]
+            if diff >= 0:
+                gains.append(diff)
+            else:
+                losses.append(abs(diff))
+        avg_gain = sum(gains) / period if gains else 0.0
+        avg_loss = sum(losses) / period if losses else 1e-9
+        rs = avg_gain / avg_loss
+        return 100 - (100 / (1 + rs))
+
+    def evaluate(
+        self,
+        strategy: Tuple[str, Mapping],
+        chart_data: Iterable[Mapping[str, float]] | None,
+        order_status: Mapping | None,
+    ) -> str:
         """Return BUY, SELL, or HOLD signal."""
-        # TODO: implement strategy rules
+
+        name, params = strategy
+        prices = [c.get("close", 0.0) for c in chart_data or []]
+
+        if name == "trend_follow" and len(prices) >= 20:
+            short = sum(prices[-5:]) / 5
+            long = sum(prices[-20:]) / 20
+            rsi = self._rsi(prices)
+            if short > long and rsi > 55:
+                return "BUY"
+            if short < long and rsi < 45:
+                return "SELL"
+
+        if name == "reversal" and len(prices) >= params.get("lookback", 20):
+            lookback = params.get("lookback", 20)
+            recent = prices[-lookback:]
+            if prices[-1] > max(recent):
+                return "SELL"
+            if prices[-1] < min(recent):
+                return "BUY"
+
+        # other strategies can be added here
+
         return "HOLD"

--- a/src/agents/learning_agent.py
+++ b/src/agents/learning_agent.py
@@ -1,10 +1,22 @@
+"""Learning agent that updates strategy weights."""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, Mapping
+
+
 class LearningAgent:
     """Agent that updates strategy weights based on performance."""
 
-    def __init__(self):
-        self.weights = {}
+    def __init__(self) -> None:
+        self.weights: Dict[str, float] = {}
 
-    def update(self, trade_history):
-        """Update strategy weights (placeholder)."""
-        # TODO: implement learning algorithm
+    def update(self, trade_history: Iterable[Mapping[str, float]]) -> Dict[str, float]:
+        """Update strategy weights based on past trade results."""
+        for trade in trade_history:
+            strat = trade.get("strategy")
+            pnl = trade.get("pnl", 0.0)
+            if strat is None:
+                continue
+            self.weights[strat] = self.weights.get(strat, 0.0) + pnl
         return self.weights

--- a/src/agents/market_sentiment.py
+++ b/src/agents/market_sentiment.py
@@ -1,13 +1,114 @@
+"""Market sentiment classifier."""
+
+from __future__ import annotations
+
+import time
+from typing import Iterable, Mapping
+
+
 class MarketSentimentAgent:
     """Agent that classifies market sentiment into five levels."""
 
     LEVELS = ["EXTREME_FEAR", "FEAR", "NEUTRAL", "GREED", "EXTREME_GREED"]
 
-    def __init__(self):
+    def __init__(self, rsi_period: int = 14, bollinger_period: int = 20) -> None:
         self.state = "NEUTRAL"
+        self.last_update = 0.0
+        self.rsi_period = rsi_period
+        self.bollinger_period = bollinger_period
 
-    def update(self, candle_data, order_book, trade_strength):
-        """Update sentiment based on market data."""
-        # TODO: implement actual indicators
-        self.state = self.LEVELS[2]
+    @staticmethod
+    def _rsi(prices: Iterable[float], period: int) -> float:
+        """Return RSI for the given price list."""
+        prices = list(prices)
+        if len(prices) <= period:
+            return 50.0
+        gains = []
+        losses = []
+        for i in range(1, period + 1):
+            diff = prices[-i] - prices[-i - 1]
+            if diff >= 0:
+                gains.append(diff)
+            else:
+                losses.append(abs(diff))
+        avg_gain = sum(gains) / period if gains else 0.0
+        avg_loss = sum(losses) / period if losses else 1e-9
+        rs = avg_gain / avg_loss
+        return 100 - (100 / (1 + rs))
+
+    def update(
+        self,
+        candle_data: Iterable[Mapping[str, float]] | None,
+        order_book: Mapping[str, float] | None,
+        trade_strength: float | None,
+    ) -> str:
+        """Update sentiment based on market data every minute."""
+
+        now = time.time()
+        if now - self.last_update < 60:
+            return self.state
+        self.last_update = now
+
+        prices = [c.get("close", 0.0) for c in candle_data or []]
+        volumes = [c.get("volume", 0.0) for c in candle_data or []]
+
+        rsi = self._rsi(prices, self.rsi_period)
+
+        if len(prices) >= self.bollinger_period:
+            recent = prices[-self.bollinger_period :]
+        else:
+            recent = prices
+        mean = sum(recent) / len(recent) if recent else 0.0
+        variance = sum((p - mean) ** 2 for p in recent) / len(recent) if recent else 0.0
+        std = variance ** 0.5
+        upper_band = mean + 2 * std
+        lower_band = mean - 2 * std
+        last_price = prices[-1] if prices else 0.0
+
+        vol_change = 0.0
+        if len(volumes) >= 2 and volumes[-2] > 0:
+            vol_change = (volumes[-1] - volumes[-2]) / volumes[-2]
+
+        bid = (order_book or {}).get("bid", 0.0)
+        ask = (order_book or {}).get("ask", 0.0)
+        book_ratio = bid / (bid + ask) if bid + ask > 0 else 0.5
+        strength = trade_strength if trade_strength is not None else 0.5
+
+        score = 0
+        if rsi > 70:
+            score += 1
+        elif rsi < 30:
+            score -= 1
+
+        if last_price > upper_band:
+            score += 1
+        elif last_price < lower_band:
+            score -= 1
+
+        if book_ratio > 0.6:
+            score += 1
+        elif book_ratio < 0.4:
+            score -= 1
+
+        if strength > 0.6:
+            score += 1
+        elif strength < 0.4:
+            score -= 1
+
+        if vol_change > 0.2:
+            score += 1
+        elif vol_change < -0.2:
+            score -= 1
+
+        if score <= -3:
+            self.state = self.LEVELS[0]
+        elif score <= -1:
+            self.state = self.LEVELS[1]
+        elif score <= 1:
+            self.state = self.LEVELS[2]
+        elif score <= 3:
+            self.state = self.LEVELS[3]
+        else:
+            self.state = self.LEVELS[4]
+
         return self.state

--- a/src/agents/position_manager.py
+++ b/src/agents/position_manager.py
@@ -1,10 +1,29 @@
+from __future__ import annotations
+
+"""Manage open trading positions."""
+
+
 class PositionManager:
     """Manage open positions."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.positions = []
 
-    def update(self, position, entry_price, current_price):
-        """Return CLOSE if exit conditions are met."""
-        # TODO: implement exit logic
+    def update(
+        self, position: dict | None, entry_price: float, current_price: float
+    ) -> str | None:
+        """Return 'CLOSE' if exit conditions are met."""
+
+        if not position:
+            return None
+
+        side = position.get("side", "LONG")
+        if side == "LONG":
+            pnl = (current_price - entry_price) / entry_price
+        else:
+            pnl = (entry_price - current_price) / entry_price
+
+        if abs(pnl) >= 0.15:
+            return "CLOSE"
+
         return None

--- a/src/agents/strategy_selector.py
+++ b/src/agents/strategy_selector.py
@@ -1,12 +1,34 @@
+from __future__ import annotations
+
+"""Strategy selector based on market sentiment."""
+
+from typing import Dict, Tuple
+
+
 class StrategySelector:
     """Select trading strategy based on market sentiment."""
 
-    def __init__(self):
-        self.current_strategy = None
+    def __init__(self) -> None:
+        self.current_strategy: Tuple[str, dict] | None = None
+        self.last_sentiment: str | None = None
+        # simple score table, can be updated by LearningAgent
+        self.strategy_scores: Dict[str, float] = {
+            "reversal": 1.0,
+            "swing": 1.0,
+            "trend_follow": 1.0,
+            "momentum": 1.0,
+            "take_profit": 1.0,
+            "hold": 1.0,
+        }
 
-    def select(self, sentiment):
+    def select(self, sentiment: str) -> Tuple[str, dict]:
         """Select a strategy ID and parameters based on sentiment."""
-        # Placeholder mapping
+
+        if sentiment == self.last_sentiment and self.current_strategy is not None:
+            return self.current_strategy
+
+        self.last_sentiment = sentiment
+
         mapping = {
             "EXTREME_FEAR": ("reversal", {"lookback": 20}),
             "FEAR": ("swing", {"risk": 0.02}),
@@ -14,5 +36,13 @@ class StrategySelector:
             "GREED": ("momentum", {"risk": 0.04}),
             "EXTREME_GREED": ("take_profit", {"risk": 0.05}),
         }
-        self.current_strategy = mapping.get(sentiment, ("hold", {}))
+
+        strat, params = mapping.get(sentiment, ("hold", {}))
+        params = dict(params)
+        params["score"] = self.strategy_scores.get(strat, 1.0)
+        self.current_strategy = (strat, params)
         return self.current_strategy
+
+    def update_score(self, strategy: str, score: float) -> None:
+        """Update stored score for a strategy."""
+        self.strategy_scores[strategy] = score


### PR DESCRIPTION
## Summary
- flesh out MarketSentimentAgent with simple indicator logic
- add score tracking and sentiment change handling in StrategySelector
- implement example entry rules in EntryDecisionAgent
- add basic exit condition in PositionManager
- expand LearningAgent for weight updates
- update main loop with demo data generation and logging

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68411547b5248320af1d5dfa0426b7c7