### PR TITLE
Add scalping focused agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ a simple PyQt5 dashboard. The agents demonstrate the following roles:
 - **VisualizerAgent**: displays the current state in a window.
 - **LearningAgent**: placeholder for future strategy learning.
 
+This demo is configured with a *scalping* focus. Indicators such as short-term
+RSI, order book ratios and Bollinger Band breaks are used to quickly assess
+market sentiment and select aggressive intraday strategies.
+
 ## Requirements
 
 - Python 3.8+

--- a/src/agents/entry_decision.py
+++ b/src/agents/entry_decision.py
@@ -1,10 +1,55 @@
+from collections import deque
+
+
 class EntryDecisionAgent:
-    """Determine trade entry signals."""
+    """Determine trade entry signals for scalping strategies."""
 
     def __init__(self):
-        pass
+        self.close_history = deque(maxlen=50)
+
+    def _moving_average(self, data, length):
+        if len(data) < length:
+            return None
+        return sum(list(data)[-length:]) / length
+
+    def _rsi(self, closes, period=14):
+        if len(closes) < period + 1:
+            return 50
+        gains = []
+        losses = []
+        closes = list(closes)
+        for i in range(1, period + 1):
+            delta = closes[-i] - closes[-i - 1]
+            if delta >= 0:
+                gains.append(delta)
+            else:
+                losses.append(-delta)
+        avg_gain = sum(gains) / period if gains else 0
+        avg_loss = sum(losses) / period if losses else 0
+        if avg_loss == 0:
+            return 100
+        rs = avg_gain / avg_loss
+        return 100 - (100 / (1 + rs))
 
     def evaluate(self, strategy, chart_data, order_status):
         """Return BUY, SELL, or HOLD signal."""
-        # TODO: implement strategy rules
+        if chart_data is None:
+            return "HOLD"
+
+        price = chart_data.get("close")
+        if price is None:
+            return "HOLD"
+        self.close_history.append(price)
+
+        short_ma = self._moving_average(self.close_history, 5)
+        long_ma = self._moving_average(self.close_history, 20)
+        rsi = self._rsi(self.close_history)
+
+        if short_ma is None or long_ma is None:
+            return "HOLD"
+
+        if short_ma > long_ma and rsi > 55:
+            return "BUY"
+        if short_ma < long_ma and rsi < 45:
+            return "SELL"
         return "HOLD"

--- a/src/agents/market_sentiment.py
+++ b/src/agents/market_sentiment.py
@@ -1,13 +1,86 @@
+import statistics
+from collections import deque
+
+
 class MarketSentimentAgent:
-    """Agent that classifies market sentiment into five levels."""
+    """Agent that classifies market sentiment into five levels for scalping."""
 
     LEVELS = ["EXTREME_FEAR", "FEAR", "NEUTRAL", "GREED", "EXTREME_GREED"]
 
     def __init__(self):
         self.state = "NEUTRAL"
+        self.prices = deque(maxlen=20)
+        self.volumes = deque(maxlen=20)
+
+    def _rsi(self, closes, period=14):
+        if len(closes) < period + 1:
+            return 50
+        gains = []
+        losses = []
+        for i in range(-period, 0):
+            delta = closes[i] - closes[i - 1]
+            if delta >= 0:
+                gains.append(delta)
+            else:
+                losses.append(-delta)
+        avg_gain = sum(gains) / period if gains else 0
+        avg_loss = sum(losses) / period if losses else 0
+        if avg_loss == 0:
+            return 100
+        rs = avg_gain / avg_loss
+        return 100 - (100 / (1 + rs))
+
+    def _bollinger_break(self, closes, period=20, std_dev=2):
+        if len(closes) < period:
+            return 0
+        sma = statistics.mean(closes[-period:])
+        std = statistics.stdev(closes[-period:])
+        upper = sma + std_dev * std
+        lower = sma - std_dev * std
+        last_price = closes[-1]
+        if last_price > upper:
+            return 1
+        if last_price < lower:
+            return -1
+        return 0
 
     def update(self, candle_data, order_book, trade_strength):
         """Update sentiment based on market data."""
-        # TODO: implement actual indicators
-        self.state = self.LEVELS[2]
+        if candle_data:
+            close = candle_data[-1].get("close")
+            volume = candle_data[-1].get("volume")
+            if close is not None:
+                self.prices.append(close)
+            if volume is not None:
+                self.volumes.append(volume)
+
+        closes = list(self.prices)
+        rsi = self._rsi(closes)
+        volume_change = 0.0
+        if len(self.volumes) > 1 and self.volumes[-2] > 0:
+            volume_change = (self.volumes[-1] - self.volumes[-2]) / self.volumes[-2]
+
+        book_ratio = 0.0
+        if order_book:
+            bid = order_book.get("bid", 0)
+            ask = order_book.get("ask", 0)
+            total = bid + ask
+            if total > 0:
+                book_ratio = (bid - ask) / total
+
+        bb_break = self._bollinger_break(closes)
+
+        score = rsi / 100 + volume_change + book_ratio + bb_break
+
+        if score < -1:
+            self.state = self.LEVELS[0]
+        elif score < -0.5:
+            self.state = self.LEVELS[1]
+        elif score < 0.5:
+            self.state = self.LEVELS[2]
+        elif score < 1:
+            self.state = self.LEVELS[3]
+        else:
+            self.state = self.LEVELS[4]
+
         return self.state

--- a/src/agents/position_manager.py
+++ b/src/agents/position_manager.py
@@ -1,10 +1,16 @@
 class PositionManager:
-    """Manage open positions."""
+    """Manage open positions and exit conditions for scalping."""
 
     def __init__(self):
         self.positions = []
 
     def update(self, position, entry_price, current_price):
         """Return CLOSE if exit conditions are met."""
-        # TODO: implement exit logic
+        if position is None:
+            return None
+        if entry_price is None or current_price is None:
+            return None
+        pnl = (current_price - entry_price) / entry_price
+        if pnl >= 0.15 or pnl <= -0.15:
+            return "CLOSE"
         return None

--- a/src/agents/strategy_selector.py
+++ b/src/agents/strategy_selector.py
@@ -1,18 +1,17 @@
 class StrategySelector:
-    """Select trading strategy based on market sentiment."""
+    """Select trading strategy based on market sentiment for scalping."""
 
     def __init__(self):
         self.current_strategy = None
 
     def select(self, sentiment):
         """Select a strategy ID and parameters based on sentiment."""
-        # Placeholder mapping
         mapping = {
-            "EXTREME_FEAR": ("reversal", {"lookback": 20}),
-            "FEAR": ("swing", {"risk": 0.02}),
-            "NEUTRAL": ("trend_follow", {"risk": 0.03}),
-            "GREED": ("momentum", {"risk": 0.04}),
-            "EXTREME_GREED": ("take_profit", {"risk": 0.05}),
+            "EXTREME_FEAR": ("scalp_reversal", {"lookback": 20, "risk": 0.01}),
+            "FEAR": ("scalp_pullback", {"risk": 0.015}),
+            "NEUTRAL": ("scalp_trend", {"risk": 0.02}),
+            "GREED": ("scalp_momentum", {"risk": 0.025}),
+            "EXTREME_GREED": ("scalp_take_profit", {"risk": 0.03}),
         }
         self.current_strategy = mapping.get(sentiment, ("hold", {}))
         return self.current_strategy


### PR DESCRIPTION
## Summary
- implement scalping logic in MarketSentimentAgent
- select scalping strategies in StrategySelector
- evaluate entry signals with short MAs and RSI in EntryDecisionAgent
- manage exits with +/-15% rule in PositionManager
- document scalping orientation in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841396838a483208d5f174f1d8cddda