### PR TITLE
Implement basic strategy framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,16 @@ a simple PyQt5 dashboard. The agents demonstrate the following roles:
 - **PositionManager**: evaluates open positions for exit conditions.
 - **LoggerAgent**: records agent activity to JSON files.
 - **VisualizerAgent**: displays the current state in a window.
-- **LearningAgent**: placeholder for future strategy learning.
+- **LearningAgent**: updates strategy weights based on trade history.
 
 ## Requirements
 
 - Python 3.8+
 - PyQt5
+- numpy
+- pandas
+- scikit-learn
+- xgboost
 
 Install dependencies:
 
@@ -27,3 +31,7 @@ Run the dashboard:
 ```bash
 python main.py
 ```
+
+The example application generates dummy market data and demonstrates how the
+agents interact. Entry signals require a confidence of at least `0.65` based on
+simple rule weights.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,5 @@
 PyQt5>=5.15
+numpy
+pandas
+scikit-learn
+xgboost

--- a/src/agents/entry_decision.py
+++ b/src/agents/entry_decision.py
@@ -1,10 +1,50 @@
+import pandas as pd
+
+
 class EntryDecisionAgent:
     """Determine trade entry signals."""
 
-    def __init__(self):
-        pass
+    CONDITION_WEIGHTS = {
+        "golden_cross": 0.5,
+        "rsi": 0.5,
+    }
+
+    def __init__(self, threshold: float = 0.65):
+        self.threshold = threshold
+
+    @staticmethod
+    def rsi(series, period: int = 14):
+        delta = series.diff()
+        up = delta.clip(lower=0)
+        down = -1 * delta.clip(upper=0)
+        ma_up = up.rolling(window=period).mean()
+        ma_down = down.rolling(window=period).mean()
+        rs = ma_up / ma_down
+        rsi = 100 - (100 / (1 + rs))
+        return rsi.iloc[-1]
+
+    def golden_cross(self, series, short=50, long=200):
+        short_ma_prev = series.rolling(window=short).mean().iloc[-2]
+        long_ma_prev = series.rolling(window=long).mean().iloc[-2]
+        short_ma_curr = series.rolling(window=short).mean().iloc[-1]
+        long_ma_curr = series.rolling(window=long).mean().iloc[-1]
+        return short_ma_prev <= long_ma_prev and short_ma_curr > long_ma_curr
 
     def evaluate(self, strategy, chart_data, order_status):
         """Return BUY, SELL, or HOLD signal."""
-        # TODO: implement strategy rules
+        df = pd.DataFrame(chart_data)
+        if len(df) < 200:
+            return "HOLD"
+
+        signals = {
+            "golden_cross": self.golden_cross(df["close"]),
+            "rsi": self.rsi(df["close"]) > 55,
+        }
+
+        confidence = sum(
+            self.CONDITION_WEIGHTS[k] for k, v in signals.items() if v
+        )
+
+        if confidence >= self.threshold:
+            return "BUY"
         return "HOLD"

--- a/src/agents/learning_agent.py
+++ b/src/agents/learning_agent.py
@@ -2,9 +2,23 @@ class LearningAgent:
     """Agent that updates strategy weights based on performance."""
 
     def __init__(self):
-        self.weights = {}
+        self.weights = {
+            "reversal": 1.0,
+            "swing": 1.0,
+            "trend_follow": 1.0,
+            "momentum": 1.0,
+            "take_profit": 1.0,
+            "hold": 1.0,
+        }
 
     def update(self, trade_history):
-        """Update strategy weights (placeholder)."""
-        # TODO: implement learning algorithm
+        """Update strategy weights based on average profit."""
+        stats = {}
+        for strategy_id, profit in trade_history:
+            stats.setdefault(strategy_id, []).append(profit)
+
+        for strategy_id, profits in stats.items():
+            avg_profit = sum(profits) / len(profits)
+            self.weights[strategy_id] = avg_profit
+
         return self.weights

--- a/src/agents/market_sentiment.py
+++ b/src/agents/market_sentiment.py
@@ -1,3 +1,6 @@
+import pandas as pd
+
+
 class MarketSentimentAgent:
     """Agent that classifies market sentiment into five levels."""
 
@@ -6,8 +9,54 @@ class MarketSentimentAgent:
     def __init__(self):
         self.state = "NEUTRAL"
 
+    @staticmethod
+    def rsi(series, period: int = 14):
+        delta = series.diff()
+        up = delta.clip(lower=0)
+        down = -1 * delta.clip(upper=0)
+        ma_up = up.rolling(window=period).mean()
+        ma_down = down.rolling(window=period).mean()
+        rs = ma_up / ma_down
+        rsi = 100 - (100 / (1 + rs))
+        return rsi.iloc[-1]
+
     def update(self, candle_data, order_book, trade_strength):
-        """Update sentiment based on market data."""
-        # TODO: implement actual indicators
-        self.state = self.LEVELS[2]
+        """Update sentiment based on market data.
+
+        Parameters
+        ----------
+        candle_data : list[dict]
+            Each dict requires ``close`` and ``volume`` keys.
+        order_book : dict
+            Dict with ``bid_volume`` and ``ask_volume`` keys.
+        trade_strength : float
+            Placeholder for additional inputs.
+        """
+
+        df = pd.DataFrame(candle_data)
+        if len(df) < 20:
+            # not enough data, keep previous state
+            return self.state
+
+        rsi_val = self.rsi(df["close"])
+        mean = df["close"].rolling(window=20).mean().iloc[-1]
+        std = df["close"].rolling(window=20).std().iloc[-1]
+        upper = mean + 2 * std
+        lower = mean - 2 * std
+        price = df["close"].iloc[-1]
+
+        bid = order_book.get("bid_volume", 1)
+        ask = order_book.get("ask_volume", 1)
+        order_ratio = bid / max(ask, 1)
+
+        if rsi_val > 80 or price > upper:
+            self.state = "EXTREME_GREED"
+        elif rsi_val > 70 or order_ratio > 1.5:
+            self.state = "GREED"
+        elif rsi_val < 20 or price < lower:
+            self.state = "EXTREME_FEAR"
+        elif rsi_val < 30 or order_ratio < 0.67:
+            self.state = "FEAR"
+        else:
+            self.state = "NEUTRAL"
         return self.state

--- a/src/agents/position_manager.py
+++ b/src/agents/position_manager.py
@@ -6,5 +6,10 @@ class PositionManager:
 
     def update(self, position, entry_price, current_price):
         """Return CLOSE if exit conditions are met."""
-        # TODO: implement exit logic
+        if position is None:
+            return None
+
+        change = (current_price - entry_price) / entry_price
+        if change >= 0.15 or change <= -0.15:
+            return "CLOSE"
         return None

--- a/src/agents/strategy_selector.py
+++ b/src/agents/strategy_selector.py
@@ -3,16 +3,30 @@ class StrategySelector:
 
     def __init__(self):
         self.current_strategy = None
+        self.strategy_scores = {
+            "reversal": 1.0,
+            "swing": 1.0,
+            "trend_follow": 1.0,
+            "momentum": 1.0,
+            "take_profit": 1.0,
+            "hold": 1.0,
+        }
 
     def select(self, sentiment):
         """Select a strategy ID and parameters based on sentiment."""
-        # Placeholder mapping
         mapping = {
-            "EXTREME_FEAR": ("reversal", {"lookback": 20}),
-            "FEAR": ("swing", {"risk": 0.02}),
-            "NEUTRAL": ("trend_follow", {"risk": 0.03}),
-            "GREED": ("momentum", {"risk": 0.04}),
-            "EXTREME_GREED": ("take_profit", {"risk": 0.05}),
+            "EXTREME_FEAR": "reversal",
+            "FEAR": "swing",
+            "NEUTRAL": "trend_follow",
+            "GREED": "momentum",
+            "EXTREME_GREED": "take_profit",
         }
-        self.current_strategy = mapping.get(sentiment, ("hold", {}))
+        strategy_id = mapping.get(sentiment, "hold")
+        params = {"risk": 0.03}
+
+        self.current_strategy = (strategy_id, params)
         return self.current_strategy
+
+    def update_scores(self, new_scores):
+        """Update internal strategy weights from LearningAgent."""
+        self.strategy_scores.update(new_scores)


### PR DESCRIPTION
## Summary
- add numerical packages in requirements
- implement RSI and Bollinger band sentiment evaluation
- choose strategy and update weights in StrategySelector
- add weighted rule evaluation in EntryDecisionAgent
- check position exit conditions
- update LearningAgent to average profits
- create dummy data loop for app
- update README with new details

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile src/agents/*.py main.py`
- `python main.py` *(fails: Qt platform plugin "xcb" couldn't load)*

------
https://chatgpt.com/codex/tasks/task_e_68414bd88db08320b2d941ec042d2449