### PR TITLE
Implement trading logic and Upbit integration

### DIFF
--- a/src/agents/entry_decision.py
+++ b/src/agents/entry_decision.py
@@ -5,6 +5,21 @@ class EntryDecisionAgent:
         pass
 
     def evaluate(self, strategy, chart_data, order_status):
-        """Return BUY, SELL, or HOLD signal."""
-        # TODO: implement strategy rules
+        """Return BUY, SELL, or HOLD signal based on the strategy."""
+        name = strategy[0] if isinstance(strategy, tuple) else strategy
+        if not chart_data:
+            return "HOLD"
+
+        recent_close = chart_data[-1]
+        avg5 = sum(chart_data[-5:]) / 5
+
+        if name == "momentum" and recent_close > avg5:
+            return "BUY"
+        if name == "reversal" and recent_close < avg5:
+            return "BUY"
+
+        if name == "take_profit" and order_status and order_status.get("has_position"):
+            if order_status.get("return_rate", 0) >= 0.05:
+                return "SELL"
+
         return "HOLD"

--- a/src/agents/learning_agent.py
+++ b/src/agents/learning_agent.py
@@ -5,6 +5,18 @@ class LearningAgent:
         self.weights = {}
 
     def update(self, trade_history):
-        """Update strategy weights (placeholder)."""
-        # TODO: implement learning algorithm
+        """Update strategy weights based on trade history."""
+        totals = {}
+        counts = {}
+        for trade in trade_history:
+            name = trade.get("strategy")
+            ret = trade.get("return", 0)
+            totals[name] = totals.get(name, 0) + ret
+            counts[name] = counts.get(name, 0) + 1
+
+        self.weights = {
+            name: totals[name] / counts[name]
+            for name in totals
+            if counts[name] > 0
+        }
         return self.weights

--- a/src/agents/logger_agent.py
+++ b/src/agents/logger_agent.py
@@ -10,13 +10,23 @@ class LoggerAgent:
         self.log_dir = Path(log_dir)
         self.log_dir.mkdir(parents=True, exist_ok=True)
 
-    def log(self, agent, action, price=None, confidence=None):
+    def log(
+        self,
+        agent,
+        action,
+        price=None,
+        confidence=None,
+        symbol=None,
+        return_rate=None,
+    ):
         entry = {
             "timestamp": datetime.utcnow().isoformat(),
             "agent": agent,
             "action": action,
             "price": price,
             "confidence": confidence,
+            "symbol": symbol,
+            "return_rate": return_rate,
         }
         filename = self.log_dir / f"{datetime.utcnow().strftime('%Y%m%d_%H%M%S%f')}.json"
         with open(filename, "w", encoding="utf-8") as f:

--- a/src/agents/market_sentiment.py
+++ b/src/agents/market_sentiment.py
@@ -1,3 +1,9 @@
+import math
+from typing import List, Optional
+
+from .utils import get_upbit_candles
+
+
 class MarketSentimentAgent:
     """Agent that classifies market sentiment into five levels."""
 
@@ -6,8 +12,50 @@ class MarketSentimentAgent:
     def __init__(self):
         self.state = "NEUTRAL"
 
-    def update(self, candle_data, order_book, trade_strength):
-        """Update sentiment based on market data."""
-        # TODO: implement actual indicators
-        self.state = self.LEVELS[2]
+    def _calc_rsi(self, closes: List[float], period: int = 20) -> float:
+        if len(closes) < period + 1:
+            return 50.0
+        gains = []
+        losses = []
+        for i in range(1, period + 1):
+            diff = closes[-i] - closes[-i - 1]
+            if diff > 0:
+                gains.append(diff)
+            else:
+                losses.append(abs(diff))
+        avg_gain = sum(gains) / period
+        avg_loss = sum(losses) / period
+        if math.isclose(avg_loss, 0):
+            return 100.0
+        rs = avg_gain / avg_loss
+        return 100 - (100 / (1 + rs))
+
+    def update(
+        self,
+        candle_data: Optional[List[float]] = None,
+        order_book=None,
+        trade_strength=None,
+    ) -> str:
+        """Update sentiment based on market data from Upbit."""
+
+        if candle_data is None:
+            try:
+                candle_data = get_upbit_candles()
+            except Exception:
+                return self.state
+
+        rsi = self._calc_rsi(candle_data, period=20)
+
+        if rsi < 30:
+            level = 0
+        elif rsi < 45:
+            level = 1
+        elif rsi < 55:
+            level = 2
+        elif rsi < 70:
+            level = 3
+        else:
+            level = 4
+
+        self.state = self.LEVELS[level]
         return self.state

--- a/src/agents/position_manager.py
+++ b/src/agents/position_manager.py
@@ -6,5 +6,13 @@ class PositionManager:
 
     def update(self, position, entry_price, current_price):
         """Return CLOSE if exit conditions are met."""
-        # TODO: implement exit logic
+        if position is None:
+            return None
+
+        if current_price >= entry_price * 1.05:
+            return "CLOSE"
+
+        if current_price <= entry_price * 0.97:
+            return "CLOSE"
+
         return None

--- a/src/agents/utils.py
+++ b/src/agents/utils.py
@@ -1,0 +1,22 @@
+import requests
+import time
+from typing import List
+
+
+def get_upbit_candles(symbol: str = "KRW-BTC", count: int = 20) -> List[float]:
+    """Fetch minute candles from Upbit and return a list of closing prices."""
+    url = "https://api.upbit.com/v1/candles/minutes/1"
+    params = {"market": symbol, "count": count}
+    while True:
+        try:
+            response = requests.get(url, params=params, timeout=5)
+            if response.status_code == 429:
+                time.sleep(1)
+                continue
+            response.raise_for_status()
+            data = response.json()
+            closes = [candle["trade_price"] for candle in reversed(data)]
+            return closes
+        except requests.RequestException as exc:
+            raise RuntimeError(f"Failed to fetch candles: {exc}") from exc
+

--- a/src/agents/visualizer.py
+++ b/src/agents/visualizer.py
@@ -11,11 +11,25 @@ class VisualizerAgent(QtWidgets.QWidget):
         self.sentiment_label = QtWidgets.QLabel("Sentiment: NEUTRAL")
         self.strategy_label = QtWidgets.QLabel("Strategy: None")
         self.position_label = QtWidgets.QLabel("Position: None")
-        for widget in [self.sentiment_label, self.strategy_label, self.position_label]:
+        self.signal_label = QtWidgets.QLabel("Signal: HOLD")
+        for widget in [
+            self.sentiment_label,
+            self.strategy_label,
+            self.position_label,
+            self.signal_label,
+        ]:
             self.layout.addWidget(widget)
         self.setLayout(self.layout)
 
-    def update_state(self, sentiment, strategy, position):
+    def update_state(self, sentiment, strategy, position, signal):
         self.sentiment_label.setText(f"Sentiment: {sentiment}")
         self.strategy_label.setText(f"Strategy: {strategy}")
-        self.position_label.setText(f"Position: {position}")
+        if isinstance(position, dict):
+            entry = position.get("entry_price")
+            rr = position.get("return_rate")
+            self.position_label.setText(
+                f"Position: entry {entry:.2f}, return {rr:.2%}"
+            )
+        else:
+            self.position_label.setText("Position: None")
+        self.signal_label.setText(f"Signal: {signal}")


### PR DESCRIPTION
## Summary
- fetch Upbit candles using a new `get_upbit_candles` helper
- classify market sentiment via RSI from recent closes
- add strategy-based entry rules and profit taking checks
- manage open positions with profit/loss exits
- record actions with additional log fields
- display sentiment, strategy, position and signal in the GUI
- compute strategy weights from trade history
- integrate real data flow in `main.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68422b4886348320b224d93d7f50a4e5