### PR TITLE
Add sentiment and position manager tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ Install dependencies:
 pip install -r requirements.txt
 ```
 
+Run the tests with `pytest`:
+
+```bash
+pytest -q
+```
+
 Run the dashboard (a Flask status server will start on port 5000):
 
 ```bash

--- a/tests/test_market_sentiment.py
+++ b/tests/test_market_sentiment.py
@@ -1,0 +1,26 @@
+import os
+import sys
+import math
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
+from agents.market_sentiment import MarketSentimentAgent
+
+
+def test_calc_rsi_insufficient_data():
+    agent = MarketSentimentAgent()
+    closes = [1, 2, 3]
+    assert agent.calc_rsi(closes, period=5) == 50.0
+
+
+def test_calc_rsi_zero_loss():
+    agent = MarketSentimentAgent()
+    closes = list(range(1, 22))  # strictly increasing
+    assert agent.calc_rsi(closes, period=20) == 100.0
+
+
+def test_calc_rsi_general_case():
+    agent = MarketSentimentAgent()
+    closes = [1, 2, 3, 4, 5, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 13, 14, 15, 16, 17]
+    rsi = agent.calc_rsi(closes, period=20)
+    assert math.isclose(rsi, 90.0, abs_tol=1e-6)

--- a/tests/test_position_manager.py
+++ b/tests/test_position_manager.py
@@ -1,0 +1,29 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
+from agents.position_manager import PositionManager
+
+
+def test_close_on_profit():
+    pm = PositionManager()
+    action = pm.update({'pos': 1}, entry_price=100, current_price=115)
+    assert action == 'CLOSE'
+
+
+def test_close_on_loss():
+    pm = PositionManager()
+    action = pm.update({'pos': 1}, entry_price=100, current_price=85)
+    assert action == 'CLOSE'
+
+
+def test_no_close_within_bounds():
+    pm = PositionManager()
+    action = pm.update({'pos': 1}, entry_price=100, current_price=100)
+    assert action is None
+
+
+def test_none_position():
+    pm = PositionManager()
+    action = pm.update(None, entry_price=100, current_price=120)
+    assert action is None


### PR DESCRIPTION
## Summary
- add test coverage for `MarketSentimentAgent.calc_rsi`
- test `PositionManager.update` profit/loss exits
- document running tests in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68423a3eaa888320842937dd80f18641