### PR TITLE
Add web dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@
 .Trashes
 ehthumbs.db
 Thumbs.db
+
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,20 +1,19 @@
 # Trading Agent Demo
 
 This repository provides a minimal example of a multi-agent trading framework with
-a simple PyQt5 dashboard. The agents demonstrate the following roles:
+a simple web dashboard built using Flask. The agents demonstrate the following roles:
 
 - **MarketSentimentAgent**: classifies market sentiment.
 - **StrategySelector**: chooses a trading strategy based on sentiment.
 - **EntryDecisionAgent**: decides whether to buy, sell, or hold.
 - **PositionManager**: evaluates open positions for exit conditions.
 - **LoggerAgent**: records agent activity to JSON files.
-- **VisualizerAgent**: displays the current state in a window.
+- **VisualizerAgent**: stores the latest state for the web dashboard.
 - **LearningAgent**: placeholder for future strategy learning.
 
 ## Requirements
 
 - Python 3.8+
-- PyQt5
 
 Install dependencies:
 
@@ -28,13 +27,13 @@ Run the tests with `pytest`:
 pytest -q
 ```
 
-Run the dashboard (a Flask status server will start on port 5000):
+Run the dashboard (a Flask web server will start on port 5000):
 
 ```bash
 python main.py
 ```
 
-You can view the current trading status by visiting `http://localhost:5000/status`.
+You can view the current trading status at `http://localhost:5000/`.
 
 ## Disclaimer / 면책 조항
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
-PyQt5>=5.15
-
 Flask>=2.2
 
 requests>=2.0

--- a/src/agents/visualizer.py
+++ b/src/agents/visualizer.py
@@ -1,35 +1,30 @@
-from PyQt5 import QtWidgets
-
-
-class VisualizerAgent(QtWidgets.QWidget):
-    """Basic window to visualize agent states."""
+class VisualizerAgent:
+    """Store the latest state for the web dashboard."""
 
     def __init__(self):
-        super().__init__()
-        self.setWindowTitle("Trading Agent Dashboard")
-        self.layout = QtWidgets.QVBoxLayout()
-        self.sentiment_label = QtWidgets.QLabel("Sentiment: NEUTRAL")
-        self.strategy_label = QtWidgets.QLabel("Strategy: None")
-        self.position_label = QtWidgets.QLabel("Position: None")
-        self.signal_label = QtWidgets.QLabel("Signal: HOLD")
-        for widget in [
-            self.sentiment_label,
-            self.strategy_label,
-            self.position_label,
-            self.signal_label,
-        ]:
-            self.layout.addWidget(widget)
-        self.setLayout(self.layout)
+        self.state = {
+            "sentiment": "NEUTRAL",
+            "strategy": None,
+            "position": None,
+            "signal": "HOLD",
+            "price": None,
+            "balance": 0.0,
+            "equity": 0.0,
+        }
 
-    def update_state(self, sentiment, strategy, position, signal):
-        self.sentiment_label.setText(f"Sentiment: {sentiment}")
-        self.strategy_label.setText(f"Strategy: {strategy}")
-        if isinstance(position, dict):
-            entry = position.get("entry_price")
-            rr = position.get("return_rate")
-            self.position_label.setText(
-                f"Position: entry {entry:.2f}, return {rr:.2%}"
-            )
-        else:
-            self.position_label.setText("Position: None")
-        self.signal_label.setText(f"Signal: {signal}")
+    def update_state(self, sentiment, strategy, position, signal, price, balance):
+        equity = balance
+        if position and isinstance(position, dict):
+            qty = position.get("quantity", 1.0)
+            equity += price * qty
+        self.state.update(
+            {
+                "sentiment": sentiment,
+                "strategy": strategy,
+                "position": position,
+                "signal": signal,
+                "price": price,
+                "balance": balance,
+                "equity": equity,
+            }
+        )

--- a/status_server.py
+++ b/status_server.py
@@ -1,21 +1,21 @@
-from flask import Flask, jsonify
+from flask import Flask, jsonify, render_template
 import threading
 
 
 def start_status_server(trading_app, host="0.0.0.0", port=5000):
     """Start a background Flask server exposing current trading status."""
 
-    app = Flask(__name__)
+    app = Flask(__name__, static_folder="static", template_folder="templates")
 
     @app.route("/status")
     def status():
-        position = trading_app.position if getattr(trading_app, "position", None) else None
-        return jsonify(
-            sentiment=getattr(trading_app.sentiment_agent, "state", None),
-            strategy=getattr(trading_app.strategy_selector, "current_strategy", None),
-            position=position,
-            signal=getattr(trading_app, "last_signal", None),
-        )
+        if hasattr(trading_app, "visualizer"):
+            return jsonify(trading_app.visualizer.state)
+        return jsonify({})
+
+    @app.route("/")
+    def dashboard():
+        return render_template("dashboard.html")
 
     thread = threading.Thread(
         target=lambda: app.run(host=host, port=port, use_reloader=False),

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Trading Dashboard</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css">
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body>
+<section class="section">
+<div class="container">
+    <h1 class="title">Trading Dashboard</h1>
+    <div class="columns">
+        <div class="column is-half">
+            <div class="box">
+                <h2 class="subtitle">BTC Price: <span id="price">-</span></h2>
+                <canvas id="priceChart"></canvas>
+            </div>
+        </div>
+        <div class="column is-half">
+            <div class="box">
+                <p>Sentiment: <span id="sentiment">-</span></p>
+                <p>Strategy: <span id="strategy">-</span></p>
+                <p>Signal: <span id="signal">-</span></p>
+                <p>Balance: <span id="balance">-</span></p>
+                <p>Equity: <span id="equity">-</span></p>
+            </div>
+        </div>
+    </div>
+</div>
+</section>
+<script>
+let ctx = document.getElementById('priceChart').getContext('2d');
+let chart = new Chart(ctx, {type: 'line', data: {labels: [], datasets: [{label:'Price', data:[], borderColor:'#3273dc'}]}, options:{scales:{x:{display:false}}}});
+async function update() {
+    const res = await fetch('/status');
+    const data = await res.json();
+    document.getElementById('sentiment').innerText = data.sentiment || '-';
+    document.getElementById('strategy').innerText = data.strategy || '-';
+    document.getElementById('signal').innerText = data.signal || '-';
+    document.getElementById('balance').innerText = data.balance ? data.balance.toFixed(2) : '-';
+    document.getElementById('equity').innerText = data.equity ? data.equity.toFixed(2) : '-';
+    document.getElementById('price').innerText = data.price ? data.price.toFixed(2) : '-';
+    if (data.price) {
+        chart.data.labels.push('');
+        chart.data.datasets[0].data.push(data.price);
+        if (chart.data.labels.length > 20) {
+            chart.data.labels.shift();
+            chart.data.datasets[0].data.shift();
+        }
+        chart.update();
+    }
+}
+setInterval(update, 2000);
+update();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- replace PyQt UI with a Flask web dashboard
- show trading state via `/` and `/status` routes
- store latest data in `VisualizerAgent`
- remove PyQt dependency
- document the web dashboard setup

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68423bfaa61c832097305b92007a6898