### PR TITLE
Fix return_rate calculation using self attribute

### DIFF
--- a/main.py
+++ b/main.py
@@ -50,7 +50,7 @@ class TradingApp:
         }
         if self.position:
             order_status["return_rate"] = (
-                current_price - self.position["entry_price"]
+                self.current_price - self.position["entry_price"]
             ) / self.position["entry_price"]
 
         signal = self.entry_agent.evaluate((strategy, params), candle_data, order_status)


### PR DESCRIPTION
## Summary
- fix `TradingApp.loop` to use `self.current_price` when computing return_rate

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6842463a5f0c8320b3fd3ee214ea4450