### PR TITLE
Add log analyzer tool and tests

### DIFF
--- a/log_analyzer.py
+++ b/log_analyzer.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from pathlib import Path
+from typing import List, Dict
+
+
+def load_logs(log_dir: str = "log") -> List[dict]:
+    """Load all ``*.json`` files from ``log_dir``.
+
+    Returns a list of log entries sorted by timestamp when available."""
+    path = Path(log_dir)
+    logs: List[dict] = []
+    if not path.is_dir():
+        return logs
+
+    for file in sorted(path.glob("*.json")):
+        try:
+            with open(file, "r", encoding="utf-8") as f:
+                entry = json.load(f)
+                logs.append(entry)
+        except Exception:
+            continue
+
+    try:
+        logs.sort(key=lambda x: x.get("timestamp", ""))
+    except Exception:
+        pass
+    return logs
+
+
+def analyze_logs(logs: List[dict]) -> Dict[str, object]:
+    """Compute basic statistics from log entries."""
+    stats: Dict[str, object] = {}
+
+    total = len(logs)
+    agent_counts: Dict[str, int] = defaultdict(int)
+    returns: List[float] = []
+    cumulative = 0.0
+    strategy_stats: Dict[str, Dict[str, int]] = defaultdict(lambda: {"wins": 0, "total": 0})
+
+    for entry in logs:
+        agent = entry.get("agent")
+        if agent:
+            agent_counts[agent] += 1
+
+        rr = entry.get("return_rate")
+        if isinstance(rr, (int, float)):
+            returns.append(rr)
+            cumulative += rr
+
+        if entry.get("action") == "SELL":
+            strat = entry.get("strategy")
+            if strat:
+                strategy_stats[strat]["total"] += 1
+                if isinstance(rr, (int, float)) and rr > 0:
+                    strategy_stats[strat]["wins"] += 1
+
+    avg_return = sum(returns) / len(returns) if returns else 0.0
+    max_return = max(returns) if returns else 0.0
+    min_return = min(returns) if returns else 0.0
+
+    win_rates = {
+        name: (val["wins"] / val["total"] if val["total"] > 0 else 0.0)
+        for name, val in strategy_stats.items()
+    }
+
+    stats["total_trades"] = total
+    stats["agent_counts"] = dict(agent_counts)
+    stats["average_return"] = avg_return
+    stats["cumulative_return"] = cumulative
+    stats["max_return"] = max_return
+    stats["min_return"] = min_return
+    stats["strategy_win_rates"] = win_rates
+
+    return stats
+
+
+def get_recent_logs(logs: List[dict], n: int = 10) -> List[dict]:
+    """Return the ``n`` most recent log entries."""
+    return logs[-n:]
+

--- a/tests/sample_logs/log1.json
+++ b/tests/sample_logs/log1.json
@@ -1,0 +1,8 @@
+{
+  "timestamp": "2024-01-01T00:00:00",
+  "agent": "EntryDecisionAgent",
+  "action": "BUY",
+  "price": 100,
+  "strategy": "trend_follow",
+  "return_rate": 0.0
+}

--- a/tests/sample_logs/log2.json
+++ b/tests/sample_logs/log2.json
@@ -1,0 +1,8 @@
+{
+  "timestamp": "2024-01-01T00:10:00",
+  "agent": "EntryDecisionAgent",
+  "action": "SELL",
+  "price": 110,
+  "strategy": "trend_follow",
+  "return_rate": 0.1
+}

--- a/tests/sample_logs/log3.json
+++ b/tests/sample_logs/log3.json
@@ -1,0 +1,8 @@
+{
+  "timestamp": "2024-01-01T00:20:00",
+  "agent": "PositionManager",
+  "action": "CLOSE",
+  "price": 120,
+  "strategy": "momentum",
+  "return_rate": 0.2
+}

--- a/tests/sample_logs/log4.json
+++ b/tests/sample_logs/log4.json
@@ -1,0 +1,8 @@
+{
+  "timestamp": "2024-01-01T00:30:00",
+  "agent": "EntryDecisionAgent",
+  "action": "SELL",
+  "price": 90,
+  "strategy": "momentum",
+  "return_rate": -0.1
+}

--- a/tests/test_log_analyzer.py
+++ b/tests/test_log_analyzer.py
@@ -1,0 +1,32 @@
+import os
+import sys
+import math
+import json
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from log_analyzer import load_logs, analyze_logs, get_recent_logs
+
+
+def test_load_and_analyze_logs():
+    log_dir = os.path.join(os.path.dirname(__file__), 'sample_logs')
+    logs = load_logs(log_dir)
+    assert len(logs) == 4
+
+    stats = analyze_logs(logs)
+    assert stats['total_trades'] == 4
+    assert stats['agent_counts']['EntryDecisionAgent'] == 3
+    assert math.isclose(stats['average_return'], 0.05, rel_tol=1e-9)
+    assert math.isclose(stats['cumulative_return'], 0.2, rel_tol=1e-9)
+    assert stats['max_return'] == 0.2
+    assert stats['min_return'] == -0.1
+    assert math.isclose(stats['strategy_win_rates']['trend_follow'], 1.0)
+    assert math.isclose(stats['strategy_win_rates']['momentum'], 0.0)
+
+
+def test_get_recent_logs():
+    log_dir = os.path.join(os.path.dirname(__file__), 'sample_logs')
+    logs = load_logs(log_dir)
+    recent = get_recent_logs(logs, n=2)
+    assert len(recent) == 2
+    assert recent[-1]['timestamp'] == '2024-01-01T00:30:00'


### PR DESCRIPTION
## Summary
- add `log_analyzer.py` with helpers for reading and analyzing JSON logs
- create sample log fixtures and tests for the log analyzer

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684246c9327c8320972501e29d528930