### PR TITLE
Add log dashboard and analyzer

### DIFF
--- a/log_analyzer.py
+++ b/log_analyzer.py
@@ -1,0 +1,32 @@
+import json
+from pathlib import Path
+from typing import List, Dict
+
+def load_logs(log_dir: str = "log") -> List[Dict]:
+    """Load log entries from the given directory."""
+    path = Path(log_dir)
+    if not path.exists():
+        return []
+    logs = []
+    for file in sorted(path.glob("*.json")):
+        try:
+            with open(file, "r", encoding="utf-8") as f:
+                logs.append(json.load(f))
+        except Exception:
+            continue
+    logs.sort(key=lambda x: x.get("timestamp", ""))
+    return logs
+
+
+def compute_statistics(logs: List[Dict]) -> Dict[str, List[float]]:
+    """Compute per-trade returns and cumulative returns."""
+    returns = []
+    cumulative = []
+    total = 1.0
+    for entry in logs:
+        rr = entry.get("return_rate")
+        if rr is not None and entry.get("action") in {"SELL", "CLOSE"}:
+            returns.append(rr)
+            total *= 1 + rr
+            cumulative.append(total - 1)
+    return {"returns": returns, "cumulative": cumulative}

--- a/status_server.py
+++ b/status_server.py
@@ -1,6 +1,8 @@
 from flask import Flask, jsonify, render_template
 import threading
 
+import log_analyzer
+
 
 def start_status_server(trading_app, host="0.0.0.0", port=5000):
     """Start a background Flask server exposing current trading status."""
@@ -16,6 +18,17 @@ def start_status_server(trading_app, host="0.0.0.0", port=5000):
     @app.route("/")
     def dashboard():
         return render_template("dashboard.html")
+
+    @app.route("/log")
+    def log_dashboard():
+        logs = log_analyzer.load_logs()
+        stats = log_analyzer.compute_statistics(logs)
+        recent = logs[-10:]
+        return render_template(
+            "log_dashboard.html",
+            stats=stats,
+            recent_logs=recent,
+        )
 
     thread = threading.Thread(
         target=lambda: app.run(host=host, port=port, use_reloader=False),

--- a/templates/log_dashboard.html
+++ b/templates/log_dashboard.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Log Dashboard</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css">
+    <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
+</head>
+<body>
+<section class="section">
+<div class="container">
+    <h1 class="title">Log Dashboard</h1>
+    <div id="chart"></div>
+    <table class="table is-striped">
+        <thead>
+        <tr><th>Timestamp</th><th>Agent</th><th>Action</th><th>Price</th><th>Return</th></tr>
+        </thead>
+        <tbody>
+        {% for log in recent_logs %}
+        <tr>
+            <td>{{ log.timestamp }}</td>
+            <td>{{ log.agent }}</td>
+            <td>{{ log.action }}</td>
+            <td>{{ log.price or '-' }}</td>
+            <td>{{ log.return_rate if log.return_rate is not none else '-' }}</td>
+        </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+</div>
+</section>
+<script>
+var returns = {{ stats.returns|tojson }};
+var cumulative = {{ stats.cumulative|tojson }};
+var x = [];
+for (let i = 0; i < returns.length; i++) { x.push(i + 1); }
+var bar = { x: x, y: returns, type: 'bar', name: 'Return' };
+var line = { x: x, y: cumulative, type: 'scatter', mode: 'lines', name: 'Cumulative' };
+Plotly.newPlot('chart', [bar, line]);
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- analyze JSON logs to compute returns
- expose `/log` route with log stats and recent entries
- render log dashboard with Plotly charts

## Testing
- `pip install -q -r requirements.txt`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684246ce55d88320b3b10a506a47f2b6