### PR TITLE
Start enhanced status server before trading loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ Run the dashboard (a Flask web server will start on port 5000):
 python main.py
 ```
 
-You can view the current trading status at `http://localhost:5000/`.
+You can view the web dashboard at `http://localhost:5000/`.
+The server also exposes a JSON status API at `http://localhost:5000/status`.
 
 ## Disclaimer / 면책 조항
 

--- a/main.py
+++ b/main.py
@@ -120,7 +120,9 @@ class TradingApp:
 
 if __name__ == "__main__":
     app = TradingApp()
-    start_status_server(app)
+    # Launch the Flask status server in a background daemon thread so
+    # that the trading loop can run uninterrupted.
+    server_thread = start_status_server(app)
     while True:
         app.loop()
         time.sleep(1)


### PR DESCRIPTION
## Summary
- start the Flask status server as a daemon thread before entering the trading loop
- document the JSON status endpoint in the README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684246ce89548320a6c4741c49fc15d0