### PR TITLE
Add log analyzer utility with comprehensive tests

### DIFF
--- a/src/log_analyzer.py
+++ b/src/log_analyzer.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict
+
+
+def analyze_logs(log_dir: str) -> Dict[str, float]:
+    """Analyze log files in ``log_dir`` and return basic performance metrics.
+
+    Metrics include the number of buy and sell actions, the average return,
+    cumulative return, and win rate. Log files are expected to be JSON files
+    produced by ``LoggerAgent``.
+    """
+    path = Path(log_dir)
+    buys = 0
+    sells = 0
+    returns = []
+
+    for file in path.glob("*.json"):
+        try:
+            with open(file, "r", encoding="utf-8") as f:
+                data = json.load(f)
+        except Exception:
+            continue
+        action = str(data.get("action", "")).upper()
+        if action == "BUY":
+            buys += 1
+        elif action in {"SELL", "CLOSE"}:
+            sells += 1
+        if action in {"SELL", "CLOSE"}:
+            ret = data.get("return_rate")
+            if isinstance(ret, (int, float)):
+                returns.append(float(ret))
+
+    avg_return = sum(returns) / len(returns) if returns else 0.0
+    cumulative = 1.0
+    for r in returns:
+        cumulative *= 1 + r
+    cumulative_return = cumulative - 1
+    win_rate = (
+        sum(1 for r in returns if r > 0) / len(returns) if returns else 0.0
+    )
+
+    return {
+        "buys": buys,
+        "sells": sells,
+        "average_return": avg_return,
+        "cumulative_return": cumulative_return,
+        "win_rate": win_rate,
+    }
+

--- a/tests/test_log_analyzer.py
+++ b/tests/test_log_analyzer.py
@@ -1,0 +1,40 @@
+import os
+import sys
+import json
+import tempfile
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+from log_analyzer import analyze_logs
+
+
+def create_log(directory, idx, action, price, return_rate):
+    data = {
+        "timestamp": "2021-01-01T00:00:00",
+        "agent": "EntryDecisionAgent",
+        "action": action,
+        "price": price,
+        "return_rate": return_rate,
+    }
+    filename = os.path.join(directory, f"log_{idx}.json")
+    with open(filename, "w", encoding="utf-8") as f:
+        json.dump(data, f)
+
+
+def test_analyze_logs_basic(tmp_path):
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+
+    create_log(log_dir, 1, "BUY", 100, 0.0)
+    create_log(log_dir, 2, "SELL", 110, 0.1)
+    create_log(log_dir, 3, "BUY", 200, 0.0)
+    create_log(log_dir, 4, "SELL", 180, -0.1)
+
+    result = analyze_logs(str(log_dir))
+
+    assert result["buys"] == 2
+    assert result["sells"] == 2
+    assert result["average_return"] == pytest.approx(0.0)
+    assert result["cumulative_return"] == pytest.approx(-0.01)
+    assert result["win_rate"] == pytest.approx(0.5)


### PR DESCRIPTION
## Summary
- add a utility `analyze_logs` that calculates trading metrics from JSON logs
- create unit test that checks analysis output on temporary BUY/SELL logs

## Testing
- `pip install -q requests Flask`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684246cefdec8320a921568dd3bd378f