### PR TITLE
Add log analysis with Flask visualization

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Flask>=2.2
 
 requests>=2.0
+matplotlib>=3.5

--- a/status_server.py
+++ b/status_server.py
@@ -1,5 +1,12 @@
 from flask import Flask, jsonify, render_template
 import threading
+from log_analyzer import (
+    load_logs,
+    analyze_logs,
+    get_recent_logs,
+    generate_bar_chart,
+    generate_line_chart,
+)
 
 
 def start_status_server(trading_app, host="0.0.0.0", port=5000):
@@ -16,6 +23,21 @@ def start_status_server(trading_app, host="0.0.0.0", port=5000):
     @app.route("/")
     def dashboard():
         return render_template("dashboard.html")
+
+    @app.route("/log")
+    def log_view():
+        logs = load_logs("log")
+        stats = analyze_logs(logs)
+        recent = get_recent_logs(logs, 10)
+        bar_chart = generate_bar_chart(stats.get("strategy_returns", {}))
+        line_chart = generate_line_chart(stats.get("cumulative_curve", []))
+        return render_template(
+            "log_dashboard.html",
+            stats=stats,
+            bar_chart=bar_chart,
+            line_chart=line_chart,
+            recent=recent,
+        )
 
     thread = threading.Thread(
         target=lambda: app.run(host=host, port=port, use_reloader=False),

--- a/templates/log_dashboard.html
+++ b/templates/log_dashboard.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Log Analysis</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css">
+</head>
+<body>
+<section class="section">
+<div class="container">
+    <h1 class="title">Log Analysis</h1>
+    <div class="content">
+        <p><strong>Total Trades:</strong> {{ stats.total_trades }}</p>
+        <p><strong>Average Return:</strong> {{ '{:.2%}'.format(stats.average_return) }}</p>
+        <p><strong>Cumulative Return:</strong> {{ '{:.2%}'.format(stats.cumulative_return) }}</p>
+        <p><strong>Max Return:</strong> {{ '{:.2%}'.format(stats.max_return) }}</p>
+        <p><strong>Min Return:</strong> {{ '{:.2%}'.format(stats.min_return) }}</p>
+    </div>
+    <div class="columns">
+        <div class="column">
+            <figure class="image">
+                <img src="data:image/png;base64,{{ bar_chart }}" alt="Strategy Returns">
+            </figure>
+        </div>
+        <div class="column">
+            <figure class="image">
+                <img src="data:image/png;base64,{{ line_chart }}" alt="Cumulative Return">
+            </figure>
+        </div>
+    </div>
+    <h2 class="subtitle">Recent Logs</h2>
+    <table class="table is-striped is-fullwidth">
+        <thead>
+            <tr>
+                <th>Time</th><th>Agent</th><th>Action</th><th>Price</th><th>Symbol</th><th>Return</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for log in recent %}
+            <tr>
+                <td>{{ log.timestamp }}</td>
+                <td>{{ log.agent }}</td>
+                <td>{{ log.action }}</td>
+                <td>{{ log.price }}</td>
+                <td>{{ log.symbol }}</td>
+                <td>{{ '{:.2%}'.format(log.return_rate) if log.return_rate is not none else '-' }}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>
+</section>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- extend log_analyzer with strategy stats and chart helpers
- add matplotlib dependency
- add /log dashboard route to Flask server
- include HTML template for log analytics

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68424ae2af6083208ec55474f3d8f24a