### PR TITLE
Improve dashboard and logging

### DIFF
--- a/src/agents/logger_agent.py
+++ b/src/agents/logger_agent.py
@@ -9,6 +9,7 @@ class LoggerAgent:
     def __init__(self, log_dir="log"):
         self.log_dir = Path(log_dir)
         self.log_dir.mkdir(parents=True, exist_ok=True)
+        self.last_log = None
 
     def log(
         self,
@@ -19,8 +20,9 @@ class LoggerAgent:
         symbol=None,
         return_rate=None,
     ):
+        timestamp = datetime.utcnow().isoformat()
         entry = {
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": timestamp,
             "agent": agent,
             "action": action,
             "price": price,
@@ -28,6 +30,21 @@ class LoggerAgent:
             "symbol": symbol,
             "return_rate": return_rate,
         }
+
+        compare = {
+            "agent": agent,
+            "action": action,
+            "price": price,
+            "symbol": symbol,
+            "return_rate": return_rate,
+        }
+        if self.last_log and all(compare.get(k) == self.last_log.get(k) for k in compare):
+            return None
+
+        self.last_log = compare
+
         filename = self.log_dir / f"{datetime.utcnow().strftime('%Y%m%d_%H%M%S%f')}.json"
         with open(filename, "w", encoding="utf-8") as f:
             json.dump(entry, f, ensure_ascii=False, indent=2)
+        return timestamp
+

--- a/src/agents/market_sentiment.py
+++ b/src/agents/market_sentiment.py
@@ -11,6 +11,9 @@ class MarketSentimentAgent:
 
     def __init__(self):
         self.state = "NEUTRAL"
+        self.rsi = 50.0
+        self.bb_score = 0
+        self.ts_score = 0
 
     def calc_rsi(self, closes: List[float], period: int = 20) -> float:
         """Return the Relative Strength Index (RSI) for the given closes.
@@ -63,6 +66,7 @@ class MarketSentimentAgent:
                 return self.state
 
         rsi = self.calc_rsi(candle_data, period=20)
+        self.rsi = rsi
 
         if len(candle_data) >= 20:
             ma = sum(candle_data[-20:]) / 20
@@ -74,6 +78,7 @@ class MarketSentimentAgent:
             bb_score = 1 if price > upper else -1 if price < lower else 0
         else:
             bb_score = 0
+        self.bb_score = bb_score
 
         ob_score = 0
         if order_book and isinstance(order_book, dict):
@@ -93,6 +98,7 @@ class MarketSentimentAgent:
                 ts_score = 1
             elif trade_strength < 0.9:
                 ts_score = -1
+        self.ts_score = ts_score
 
         score = 0
         if rsi > 70:

--- a/static/status.js
+++ b/static/status.js
@@ -13,9 +13,33 @@ async function refresh() {
         } else {
             document.getElementById('position').innerText = '-';
         }
+        document.getElementById('weight').innerText = (data.weight !== undefined && data.weight !== null) ? data.weight.toFixed(2) : '-';
+        document.getElementById('rsi').innerText = (data.rsi !== undefined && data.rsi !== null) ? data.rsi.toFixed(2) : '-';
+        document.getElementById('bb_score').innerText = data.bb_score !== undefined ? data.bb_score : '-';
+        document.getElementById('ts_score').innerText = data.ts_score !== undefined ? data.ts_score : '-';
+        if (data.return_rate !== null && data.return_rate !== undefined) {
+            const elem = document.getElementById('return_rate');
+            const val = (data.return_rate * 100).toFixed(2);
+            elem.innerText = val + '%';
+            elem.classList.toggle('positive', data.return_rate > 0);
+            elem.classList.toggle('negative', data.return_rate < 0);
+        } else {
+            document.getElementById('return_rate').innerText = '-';
+        }
+        document.getElementById('last_trade_time').innerText = data.last_trade_time || '-';
+        if (data.cumulative_return !== null && data.cumulative_return !== undefined) {
+            const elem = document.getElementById('cumulative_return');
+            const val = (data.cumulative_return * 100).toFixed(2);
+            elem.innerText = val + '%';
+            elem.classList.toggle('positive', data.cumulative_return > 0);
+            elem.classList.toggle('negative', data.cumulative_return < 0);
+        } else {
+            document.getElementById('cumulative_return').innerText = '-';
+        }
     } catch (e) {
         console.error(e);
     }
 }
 setInterval(refresh, 1000);
 refresh();
+

--- a/static/styles.css
+++ b/static/styles.css
@@ -1,0 +1,5 @@
+.card-heading{font-size:0.8rem;color:#666;}
+.card-value{font-size:2rem;font-weight:bold;}
+.positive{color:#1b9c1b;}
+.negative{color:#c0392b;}
+

--- a/status_server.py
+++ b/status_server.py
@@ -16,6 +16,13 @@ state_store = {
     "price": None,
     "balance": 0.0,
     "equity": 0.0,
+    "weight": None,
+    "rsi": None,
+    "bb_score": None,
+    "ts_score": None,
+    "return_rate": None,
+    "cumulative_return": 0.0,
+    "last_trade_time": None,
 }
 
 
@@ -64,3 +71,4 @@ def start_status_server(host: str = "0.0.0.0", port: int = 5000):
     )
     thread.start()
     return thread
+

--- a/templates/status.html
+++ b/templates/status.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <title>Status Dashboard</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css">
+    <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
 </head>
 <body>
 <section class="section">
@@ -13,37 +14,79 @@
         <div class="column is-one-third">
             <div class="box has-text-centered">
                 <p class="heading">Sentiment</p>
-                <p id="sentiment" class="title">-</p>
+                <p id="sentiment" class="title card-value">-</p>
             </div>
         </div>
         <div class="column is-one-third">
             <div class="box has-text-centered">
                 <p class="heading">Strategy</p>
-                <p id="strategy" class="title">-</p>
+                <p id="strategy" class="title card-value">-</p>
             </div>
         </div>
         <div class="column is-one-third">
             <div class="box has-text-centered">
                 <p class="heading">Signal</p>
-                <p id="signal" class="title">-</p>
+                <p id="signal" class="title card-value">-</p>
             </div>
         </div>
         <div class="column is-one-third">
             <div class="box has-text-centered">
                 <p class="heading">Price</p>
-                <p id="price" class="title">-</p>
+                <p id="price" class="title card-value">-</p>
             </div>
         </div>
         <div class="column is-one-third">
             <div class="box has-text-centered">
                 <p class="heading">Balance</p>
-                <p id="balance" class="title">-</p>
+                <p id="balance" class="title card-value">-</p>
             </div>
         </div>
         <div class="column is-one-third">
             <div class="box has-text-centered">
                 <p class="heading">Position</p>
-                <p id="position" class="title">-</p>
+                <p id="position" class="title card-value">-</p>
+            </div>
+        </div>
+        <div class="column is-one-third">
+            <div class="box has-text-centered">
+                <p class="heading">Weight</p>
+                <p id="weight" class="title card-value">-</p>
+            </div>
+        </div>
+        <div class="column is-one-third">
+            <div class="box has-text-centered">
+                <p class="heading">RSI</p>
+                <p id="rsi" class="title card-value">-</p>
+            </div>
+        </div>
+        <div class="column is-one-third">
+            <div class="box has-text-centered">
+                <p class="heading">Bollinger</p>
+                <p id="bb_score" class="title card-value">-</p>
+            </div>
+        </div>
+        <div class="column is-one-third">
+            <div class="box has-text-centered">
+                <p class="heading">Trade Strength</p>
+                <p id="ts_score" class="title card-value">-</p>
+            </div>
+        </div>
+        <div class="column is-one-third">
+            <div class="box has-text-centered">
+                <p class="heading">Return Rate</p>
+                <p id="return_rate" class="title card-value">-</p>
+            </div>
+        </div>
+        <div class="column is-one-third">
+            <div class="box has-text-centered">
+                <p class="heading">Last Trade</p>
+                <p id="last_trade_time" class="title card-value">-</p>
+            </div>
+        </div>
+        <div class="column is-one-third">
+            <div class="box has-text-centered">
+                <p class="heading">Cumulative</p>
+                <p id="cumulative_return" class="title card-value">-</p>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- avoid duplicate log writes by storing previous log entry
- track RSI, Bollinger score, and trade strength in sentiment agent
- propagate detailed status to Flask server and dashboard
- extend status API and UI with strategy weight and returns
- add styling for dashboard values

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684252f3bb3883208b6378aa269d8d26