### PR TITLE
Implement orderbook weighted strategy

### DIFF
--- a/tests/test_entry_decision.py
+++ b/tests/test_entry_decision.py
@@ -17,3 +17,27 @@ def test_golden_cross_requires_length():
     chart_data = [1] * 20 + [2] * 4
     assert agent.evaluate("momentum", chart_data, None) == "HOLD"
 
+
+def test_orderbook_weighted_buy():
+    agent = EntryDecisionAgent()
+    order_book = {
+        "bids": [{"price": 100, "volume": 2}] * 10,
+        "asks": [{"price": 99, "volume": 1}] * 10,
+    }
+    chart = [1] * 25
+    res = agent.evaluate(("orderbook_weighted", {}), chart, None, order_book)
+    assert isinstance(res, dict)
+    assert res["signal"] == "BUY"
+
+
+def test_orderbook_weighted_sell():
+    agent = EntryDecisionAgent()
+    order_book = {
+        "bids": [{"price": 100, "volume": 1}] * 10,
+        "asks": [{"price": 101, "volume": 2}] * 10,
+    }
+    chart = [1] * 25
+    res = agent.evaluate(("orderbook_weighted", {}), chart, None, order_book)
+    assert isinstance(res, dict)
+    assert res["signal"] == "SELL"
+


### PR DESCRIPTION
## Summary
- extend Upbit orderbook util to return top 10 price levels
- add normalized orderbook strength calculation using price/volume
- implement `orderbook_weighted` strategy logic with BUY/SELL/HOLD
- test entry decision logic for the new strategy

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842614a4d608320912f4911ddec9cb3