### PR TITLE
Add logging for entry conditions and denial reasons

### DIFF
--- a/src/agents/logger_agent.py
+++ b/src/agents/logger_agent.py
@@ -11,6 +11,16 @@ class LoggerAgent:
         self.log_dir.mkdir(parents=True, exist_ok=True)
         self.last_log = None
 
+    def log_event(self, data: dict) -> str:
+        """Write an arbitrary event dictionary to a JSON file."""
+        timestamp = datetime.utcnow().isoformat()
+        data = dict(data)
+        data.setdefault("timestamp", timestamp)
+        filename = self.log_dir / f"{datetime.utcnow().strftime('%Y%m%d_%H%M%S%f')}.json"
+        with open(filename, "w", encoding="utf-8") as f:
+            json.dump(data, f, ensure_ascii=False, indent=2)
+        return data["timestamp"]
+
     def log(
         self,
         agent,

--- a/src/agents/position_manager.py
+++ b/src/agents/position_manager.py
@@ -1,5 +1,7 @@
 """Utilities for managing trading positions and capital."""
 
+from typing import Optional
+
 # Initial capital for the trading system (in KRW)
 INITIAL_CAPITAL = 1_000_000
 
@@ -20,6 +22,17 @@ def calculate_order_amount(cash):
     """Return the order amount for a new trade given current cash."""
 
     return cash * BUY_RATE
+
+
+def entry_block_reason(has_position: bool, confidence: Optional[float], score_percent: Optional[float]) -> Optional[str]:
+    """Return a reason string if trade entry should be denied."""
+    if has_position:
+        return "ALREADY_IN_POSITION"
+    if confidence is not None and confidence < 0.7:
+        return "LOW_CONFIDENCE"
+    if score_percent is not None and score_percent < 75:
+        return "INSUFFICIENT_CONDITION_SCORE"
+    return None
 
 
 class PositionManager:

--- a/status_server.py
+++ b/status_server.py
@@ -107,12 +107,21 @@ def start_status_server(host: str = "0.0.0.0", port: int = 5000, *, position_man
         recent = get_recent_logs(logs, 10)
         bar_chart = generate_bar_chart(stats.get("strategy_returns", {}))
         line_chart = generate_line_chart(stats.get("cumulative_curve", []))
+        score_vals = [l.get("score_percent") for l in logs if l.get("type") == "condition_evaluation"]
+        avg_score = sum(score_vals) / len(score_vals) if score_vals else 0.0
+        reason_stats = {}
+        for l in logs:
+            if l.get("type") == "entry_denied":
+                r = l.get("reason")
+                reason_stats[r] = reason_stats.get(r, 0) + 1
         return render_template(
             "log.html",
             stats=stats,
             bar_chart=bar_chart,
             line_chart=line_chart,
             recent=recent,
+            average_score=avg_score,
+            reason_stats=reason_stats,
         )
 
     thread = threading.Thread(

--- a/templates/log.html
+++ b/templates/log.html
@@ -15,6 +15,7 @@
         <p><strong>Cumulative Return:</strong> {{ '{:.2%}'.format(stats.cumulative_return) }}</p>
         <p><strong>Max Return:</strong> {{ '{:.2%}'.format(stats.max_return) }}</p>
         <p><strong>Min Return:</strong> {{ '{:.2%}'.format(stats.min_return) }}</p>
+        <p><strong>Avg. Condition Score:</strong> {{ '{:.1f}%'.format(average_score) }}</p>
     </div>
     <div class="columns">
         <div class="column">
@@ -28,6 +29,12 @@
             </figure>
         </div>
     </div>
+    <h2 class="subtitle">Entry Denial Reasons</h2>
+    <ul>
+        {% for reason, cnt in reason_stats.items() %}
+        <li>{{ reason }}: {{ cnt }}</li>
+        {% endfor %}
+    </ul>
     <h2 class="subtitle">Recent Logs</h2>
     <table class="table is-striped is-fullwidth">
         <thead>


### PR DESCRIPTION
## Summary
- track condition scores and compute percent satisfied in `EntryDecisionAgent`
- expose helper to explain why entry is blocked in `PositionManager`
- log generic events via new `LoggerAgent.log_event`
- report entry approvals/denials in `main`
- display average condition score and denial reasons on log page

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684276b089c08320a75af8a7e21abfd7