### PR TITLE
Add nearest failed condition highlight

### DIFF
--- a/main.py
+++ b/main.py
@@ -206,6 +206,7 @@ class TradingApp:
             rsi=rsi,
             bb_score=bb_score,
             ts_score=ts_score,
+            nearest_failed=self.entry_agent.nearest_failed,
             return_rate=return_rate,
             cumulative_return=cumulative_return,
             last_trade_time=self.last_trade_time,
@@ -229,6 +230,7 @@ if __name__ == "__main__":
             ask_volume=orderbook.get("ask_volume"),
             buy_count=app.position_manager.total_buys,
             sell_count=app.position_manager.total_sells,
+            nearest_failed=app.entry_agent.nearest_failed,
         )
         app.loop()
         time.sleep(2)

--- a/static/status.js
+++ b/static/status.js
@@ -23,6 +23,15 @@ async function refresh() {
         document.getElementById('rsi').innerText = (data.rsi !== undefined && data.rsi !== null) ? data.rsi.toFixed(2) : '-';
         document.getElementById('bb_score').innerText = data.bb_score !== undefined ? data.bb_score : '-';
         document.getElementById('ts_score').innerText = data.ts_score !== undefined ? data.ts_score : '-';
+        if (data.nearest_failed) {
+            const nf = data.nearest_failed;
+            const text = `${nf.condition} (${nf.diff.toFixed(2)})`;
+            const elem = document.getElementById('nearest_failed');
+            elem.innerText = text;
+            elem.classList.toggle('negative', nf.diff < 0);
+        } else {
+            document.getElementById('nearest_failed').innerText = '-';
+        }
         if (data.return_rate !== null && data.return_rate !== undefined) {
             const elem = document.getElementById('return_rate');
             const val = (data.return_rate * 100).toFixed(2);

--- a/status_server.py
+++ b/status_server.py
@@ -26,6 +26,7 @@ state_store = {
     "rsi": None,
     "bb_score": None,
     "ts_score": None,
+    "nearest_failed": None,
     "return_rate": None,
     "cumulative_return": 0.0,
     "last_trade_time": None,

--- a/templates/status.html
+++ b/templates/status.html
@@ -75,6 +75,12 @@
         </div>
         <div class="column is-one-third">
             <div class="box has-text-centered">
+                <p class="heading">가장 근접 실패</p>
+                <p id="nearest_failed" class="title card-value">-</p>
+            </div>
+        </div>
+        <div class="column is-one-third">
+            <div class="box has-text-centered">
                 <p class="heading">매수/매도 비율</p>
                 <p id="orderbook_ratio" class="title card-value">-</p>
             </div>

--- a/tests/test_entry_decision.py
+++ b/tests/test_entry_decision.py
@@ -41,3 +41,14 @@ def test_orderbook_weighted_sell():
     assert isinstance(res, dict)
     assert res["signal"] == "SELL"
 
+
+def test_nearest_failed_condition():
+    agent = EntryDecisionAgent()
+    chart = [100] * 20 + [100.5, 100, 100.4, 99.8, 100.2]
+    result = agent.evaluate("momentum", chart, None)
+    assert result == "HOLD"
+    nf = agent.nearest_failed
+    assert nf["condition"] == "rsi_above_55"
+    assert nf["passed"] is False
+    assert nf["diff"] == pytest.approx(-0.83, abs=0.1)
+


### PR DESCRIPTION
## Summary
- track nearest failing condition in `EntryDecisionAgent`
- expose nearest failure in dashboard state and UI
- display nearest failure via JS and HTML
- test new behaviour

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842797fd4288320a2f7cecabfe7ecd3