### PR TITLE
Enhance trade log visualization

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -2,4 +2,11 @@
 .card-value{font-size:2rem;font-weight:bold;}
 .positive{color:#1b9c1b;}
 .negative{color:#c0392b;}
+.trade-flash{
+  animation: flash-bg 1s ease-in-out;
+}
+@keyframes flash-bg{
+  from{background-color:#ffeaa7;}
+  to{background-color:transparent;}
+}
 

--- a/templates/status.html
+++ b/templates/status.html
@@ -106,6 +106,14 @@
     </div>
     <div id="weights_chart" style="height:300px;"></div>
 
+    <h3>📊 포지션별 수익률</h3>
+    <table class="table is-striped is-fullwidth" id="profitTable">
+      <thead>
+        <tr><th>진입가</th><th>수량</th><th>수익률</th></tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+
     <div>
       🟢 매수 횟수: <span id="buyCount">0</span>회<br>
       🔴 매도 횟수: <span id="sellCount">0</span>회


### PR DESCRIPTION
## Summary
- convert UTC timestamps to KST when displaying log data
- animate latest trades and add profit table for current positions
- show KST times on log analysis page

## Testing
- `pip install -q matplotlib requests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684282a2e7288320b922eb6fc217c596