### PR TITLE
Add trade time conversion and profit table

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -10,3 +10,20 @@
   to{background-color:transparent;}
 }
 
+.buy-highlight{
+  animation: blink-green 1s ease-in-out;
+}
+.sell-highlight{
+  animation: blink-red 1s ease-in-out;
+}
+
+@keyframes blink-green{
+  0%{background-color:#e6ffe6;}
+  100%{background-color:transparent;}
+}
+
+@keyframes blink-red{
+  0%{background-color:#ffe6e6;}
+  100%{background-color:transparent;}
+}
+

--- a/templates/status.html
+++ b/templates/status.html
@@ -106,10 +106,10 @@
     </div>
     <div id="weights_chart" style="height:300px;"></div>
 
-    <h3>📊 포지션별 수익률</h3>
-    <table class="table is-striped is-fullwidth" id="profitTable">
+    <h3>📊 실시간 수익률 (보유 중)</h3>
+    <table class="table is-striped is-fullwidth" id="returnTable">
       <thead>
-        <tr><th>진입가</th><th>수량</th><th>수익률</th></tr>
+        <tr><th>포지션</th><th>진입가</th><th>현재가</th><th>수익률</th></tr>
       </thead>
       <tbody></tbody>
     </table>


### PR DESCRIPTION
## Summary
- convert trade timestamps to KST with helper
- add highlight styles for BUY/SELL entries
- track live returns of open positions

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6842869e793c8320b4423df72c7e2d4f