### PR TITLE
Add DailyLogger for desktop logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ a simple web dashboard built using Flask. The agents demonstrate the following r
 - **EntryDecisionAgent**: decides whether to buy, sell, or hold.
 - **PositionManager**: evaluates open positions for exit conditions.
 - **LoggerAgent**: records agent activity to JSON files.
+- **DailyLogger**: appends daily success and failure entries in `NOVA_LOGS` on your Desktop.
 - **Flask Status Server**: serves a web dashboard and JSON API.
 - **LearningAgent**: placeholder for future strategy learning.
 

--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -1,0 +1,17 @@
+from .market_sentiment import MarketSentimentAgent
+from .strategy_selector import StrategySelector
+from .entry_decision import EntryDecisionAgent
+from .position_manager import PositionManager
+from .logger_agent import LoggerAgent
+from .learning_agent import LearningAgent
+from .daily_logger import DailyLogger
+
+__all__ = [
+    'MarketSentimentAgent',
+    'StrategySelector',
+    'EntryDecisionAgent',
+    'PositionManager',
+    'LoggerAgent',
+    'LearningAgent',
+    'DailyLogger',
+]

--- a/src/agents/daily_logger.py
+++ b/src/agents/daily_logger.py
@@ -1,0 +1,50 @@
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+
+
+class DailyLogger:
+    """Simple logger that appends success and failure events by day."""
+
+    def __init__(self, base_dir: str | os.PathLike | None = None):
+        desktop = Path.home() / "Desktop" if base_dir is None else Path(base_dir)
+        self.log_dir = desktop / "NOVA_LOGS"
+        self.log_dir.mkdir(parents=True, exist_ok=True)
+
+    def _get_log_file(self, kind: str) -> Path:
+        date_str = datetime.now().strftime("%Y-%m-%d")
+        filename = f"trade_{kind}_{date_str}.json"
+        return self.log_dir / filename
+
+    def log_failure(self, agent: str, reason: str) -> None:
+        entry = {
+            "timestamp": datetime.now().isoformat(timespec="seconds"),
+            "agent": agent,
+            "action": "FAILURE",
+            "reason": reason,
+        }
+        path = self._get_log_file("failures")
+        with open(path, "a", encoding="utf-8") as f:
+            f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+
+    def log_success(
+        self,
+        agent: str,
+        action: str,
+        *,
+        price: float,
+        strategy: str,
+        return_rate: float,
+    ) -> None:
+        entry = {
+            "timestamp": datetime.now().isoformat(timespec="seconds"),
+            "agent": agent,
+            "action": action,
+            "price": price,
+            "strategy": strategy,
+            "return_rate": round(return_rate, 4),
+        }
+        path = self._get_log_file("success")
+        with open(path, "a", encoding="utf-8") as f:
+            f.write(json.dumps(entry, ensure_ascii=False) + "\n")

--- a/tests/test_daily_logger.py
+++ b/tests/test_daily_logger.py
@@ -1,0 +1,24 @@
+import json
+import os
+import sys
+import datetime
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+from agents.daily_logger import DailyLogger
+
+
+def test_daily_logger_write(tmp_path):
+    logger = DailyLogger(base_dir=tmp_path)
+    logger.log_failure('AgentA', 'reason')
+    logger.log_success('AgentB', 'BUY', price=1.23, strategy='s', return_rate=0.1)
+    date_str = datetime.datetime.now().strftime('%Y-%m-%d')
+    fail_file = tmp_path / 'NOVA_LOGS' / f'trade_failures_{date_str}.json'
+    success_file = tmp_path / 'NOVA_LOGS' / f'trade_success_{date_str}.json'
+    assert fail_file.exists()
+    assert success_file.exists()
+    with open(fail_file, encoding='utf-8') as f:
+        data = json.loads(f.readline())
+    assert data['agent'] == 'AgentA'
+    with open(success_file, encoding='utf-8') as f:
+        data = json.loads(f.readline())
+    assert data['action'] == 'BUY'


### PR DESCRIPTION
## Summary
- implement `DailyLogger` class to log daily failures and successes in `NOVA_LOGS` on the user's Desktop
- expose `DailyLogger` via `agents.__init__`
- document DailyLogger in README
- add tests for DailyLogger

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842ce6945788320bff0e34e718c245f