### PR TITLE
Add session-based logger

### DIFF
--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -5,6 +5,7 @@ from .position_manager import PositionManager
 from .logger_agent import LoggerAgent
 from .learning_agent import LearningAgent
 from .daily_logger import DailyLogger
+from .session_logger import SessionLogger
 
 __all__ = [
     'MarketSentimentAgent',
@@ -12,6 +13,7 @@ __all__ = [
     'EntryDecisionAgent',
     'PositionManager',
     'LoggerAgent',
+    'SessionLogger',
     'LearningAgent',
     'DailyLogger',
 ]

--- a/src/agents/session_logger.py
+++ b/src/agents/session_logger.py
@@ -1,0 +1,42 @@
+import json
+from datetime import datetime
+from pathlib import Path
+
+
+class SessionLogger:
+    """Unified logger that appends entries to a single file per session."""
+
+    def __init__(self, base_dir: str | Path | None = None):
+        desktop_path = Path.home() / "Desktop" if base_dir is None else Path(base_dir)
+        self.log_dir = desktop_path / "NOVA_LOGS"
+        self.log_dir.mkdir(parents=True, exist_ok=True)
+        session_id = datetime.now().strftime("%Y%m%d_%H%M%S")
+        self.log_file = self.log_dir / f"trade_log_{session_id}.json"
+
+    def log_entry(self, data: dict) -> None:
+        data = dict(data)
+        data.setdefault("timestamp", datetime.now().isoformat(timespec="seconds"))
+        with open(self.log_file, "a", encoding="utf-8") as f:
+            f.write(json.dumps(data, ensure_ascii=False) + "\n")
+
+    def log_success(self, agent: str, action: str, *, price: float, strategy: str, return_rate: float) -> None:
+        self.log_entry({
+            "agent": agent,
+            "action": action,
+            "price": price,
+            "strategy": strategy,
+            "return_rate": round(return_rate, 4),
+        })
+
+    def log_failure(self, agent: str, reason: str) -> None:
+        self.log_entry({
+            "agent": agent,
+            "action": "FAILURE",
+            "reason": reason,
+        })
+
+    def log_hold(self, agent: str) -> None:
+        self.log_entry({
+            "agent": agent,
+            "action": "HOLD",
+        })


### PR DESCRIPTION
## Summary
- introduce `SessionLogger` for unified session logging
- expose new logger in package exports

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842d367b1b48320abbbd0411c4ddba6