### PR TITLE
Add get_log_path helper and session logger tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ a simple web dashboard built using Flask. The agents demonstrate the following r
 - **PositionManager**: evaluates open positions for exit conditions.
 - **LoggerAgent**: records agent activity to JSON files.
 - **DailyLogger**: appends daily success and failure entries in `NOVA_LOGS` on your Desktop.
+- **SessionLogger**: writes all actions for a single run to `NOVA_LOGS/trade_log_<timestamp>.json`.
 - **Flask Status Server**: serves a web dashboard and JSON API.
 - **LearningAgent**: placeholder for future strategy learning.
 

--- a/src/agents/session_logger.py
+++ b/src/agents/session_logger.py
@@ -40,3 +40,7 @@ class SessionLogger:
             "agent": agent,
             "action": "HOLD",
         })
+
+    def get_log_path(self) -> str:
+        """Return the path to the session log file as a string."""
+        return str(self.log_file)

--- a/tests/test_session_logger.py
+++ b/tests/test_session_logger.py
@@ -1,0 +1,21 @@
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
+from agents.session_logger import SessionLogger
+
+
+def test_session_logger(tmp_path):
+    logger = SessionLogger(base_dir=tmp_path)
+    logger.log_success('A', 'BUY', price=1.0, strategy='s', return_rate=0.1)
+    logger.log_failure('B', 'error')
+    logger.log_hold('C')
+
+    log_files = list((tmp_path / 'NOVA_LOGS').glob('trade_log_*.json'))
+    assert len(log_files) == 1
+    with open(log_files[0], encoding='utf-8') as f:
+        lines = [json.loads(line) for line in f.read().splitlines()]
+    assert lines[0]['action'] == 'BUY'
+    assert lines[1]['action'] == 'FAILURE'
+    assert lines[2]['action'] == 'HOLD'


### PR DESCRIPTION
## Summary
- document new SessionLogger in README
- expose `get_log_path` helper on `SessionLogger`
- add unit test for SessionLogger

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842d672fec48320bbe5b00971bb7632