### PR TITLE
Refactor trading axes

### DIFF
--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -2,6 +2,8 @@ from .market_sentiment import MarketSentimentAgent
 from .strategy_selector import StrategySelector
 from .entry_decision import EntryDecisionAgent
 from .position_manager import PositionManager
+from .risk_manager import RiskManager
+from .emotion_axis import EmotionAxis
 from .logger_agent import LoggerAgent
 from .learning_agent import LearningAgent
 from .daily_logger import DailyLogger
@@ -12,6 +14,8 @@ __all__ = [
     'StrategySelector',
     'EntryDecisionAgent',
     'PositionManager',
+    'RiskManager',
+    'EmotionAxis',
     'LoggerAgent',
     'SessionLogger',
     'LearningAgent',

--- a/src/agents/emotion_axis.py
+++ b/src/agents/emotion_axis.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+from datetime import datetime, timedelta
+
+
+class EmotionAxis:
+    """Track consecutive failures and enforce cooldown/pause rules."""
+
+    def __init__(self) -> None:
+        self.consecutive_failures = 0
+        self.cooldown_until: datetime | None = None
+
+    def record_result(self, success: bool) -> None:
+        """Record condition evaluation result and update cooldown state."""
+        if success:
+            self.consecutive_failures = 0
+            return
+        self.consecutive_failures += 1
+        if self.consecutive_failures >= 3:
+            self.cooldown_until = datetime.utcnow() + timedelta(minutes=30)
+            self.consecutive_failures = 0
+
+    def in_cooldown(self) -> bool:
+        """Return ``True`` if trading is currently paused."""
+        return bool(self.cooldown_until and datetime.utcnow() < self.cooldown_until)
+
+    def should_pause_for_greed(self, rsi: float) -> bool:
+        """Return ``True`` if RSI indicates extreme greed (>85)."""
+        return rsi > 85

--- a/src/agents/learning_agent.py
+++ b/src/agents/learning_agent.py
@@ -1,19 +1,49 @@
+import time
+
+
 class LearningAgent:
     """Agent that updates strategy weights based on performance."""
 
     def __init__(self):
         self.weights = {}
+        self.history = []
 
-    def update(self, trade_history):
-        """Update strategy weights using EWMA of recent positive returns."""
+    def record_trade(self, strategy: str, return_rate: float) -> None:
+        """Store trade result for later evaluation."""
+        self.history.append(
+            {
+                "strategy": strategy,
+                "return": return_rate,
+                "timestamp": time.time(),
+            }
+        )
+
+    def update(self, trade_history=None):
+        """Update strategy weights using recent one week of trades."""
+
+        if trade_history is None:
+            trade_history = self.history
+
+        one_week_ago = time.time() - 7 * 24 * 3600
+        recent = [t for t in trade_history if t.get("timestamp", 0) >= one_week_ago]
 
         alpha = 0.3
-        for trade in trade_history:
+        for trade in recent:
             name = trade.get("strategy")
             ret = trade.get("return", 0)
-            if ret <= 0:
-                continue
-            old = self.weights.get(name, 0.0)
-            self.weights[name] = alpha * ret + (1 - alpha) * old
+            old = self.weights.get(name, 1.0)
+            self.weights[name] = old + alpha * ret
+
+        # remove strategies with consistently negative weights
+        for name, weight in list(self.weights.items()):
+            if weight < -1:
+                del self.weights[name]
 
         return self.weights
+
+    def adjust_from_signal(self, strategy: str, score_percent: float, confidence: float | None) -> None:
+        """Lightweight online adjustment using condition score and confidence."""
+        conf = confidence if confidence is not None else 1.0
+        weight = self.weights.get(strategy, 1.0)
+        weight += 0.01 * (score_percent / 100.0) * conf
+        self.weights[strategy] = weight

--- a/src/agents/risk_manager.py
+++ b/src/agents/risk_manager.py
@@ -1,0 +1,10 @@
+class RiskManager:
+    """Adjust order amounts based on volatility and manage exposure."""
+
+    def __init__(self, max_trade_pct: float = 0.1) -> None:
+        self.max_trade_pct = max_trade_pct
+
+    def order_amount(self, balance: float, volatility: float) -> float:
+        """Return recommended order amount."""
+        factor = max(0.5, 1 - volatility * 50)
+        return balance * self.max_trade_pct * factor

--- a/tests/test_position_manager.py
+++ b/tests/test_position_manager.py
@@ -7,19 +7,23 @@ from agents.position_manager import PositionManager
 
 def test_close_on_profit():
     pm = PositionManager()
-    action = pm.update({'pos': 1}, entry_price=100, current_price=115)
+    action = pm.update({'quantity': 1}, entry_price=100, current_price=103)
     assert action == 'CLOSE'
 
 
-def test_close_on_loss():
+def test_partial_then_close_on_loss():
     pm = PositionManager()
-    action = pm.update({'pos': 1}, entry_price=100, current_price=85)
+    pos = {'quantity': 1}
+    action = pm.update(pos, entry_price=100, current_price=98)
+    assert action == 'PARTIAL_CLOSE'
+    assert pos['quantity'] == 0.5
+    action = pm.update(pos, entry_price=100, current_price=97)
     assert action == 'CLOSE'
 
 
 def test_no_close_within_bounds():
     pm = PositionManager()
-    action = pm.update({'pos': 1}, entry_price=100, current_price=100)
+    action = pm.update({'quantity': 1}, entry_price=100, current_price=100)
     assert action is None
 
 
@@ -27,3 +31,4 @@ def test_none_position():
     pm = PositionManager()
     action = pm.update(None, entry_price=100, current_price=120)
     assert action is None
+


### PR DESCRIPTION
## Summary
- add `EmotionAxis` for cooldown logic
- add `RiskManager` with volatility-based sizing
- enhance `StrategySelector` with strategy_mode state
- update `LearningAgent`, `PositionManager`, and trading loop
- adjust tests for new exit logic

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842ddb366008320ade4fe6420d2ddfd