### PR TITLE
Integrate RiskManager and dynamic strategy phase

### DIFF
--- a/src/agents/logger_agent.py
+++ b/src/agents/logger_agent.py
@@ -21,6 +21,27 @@ class LoggerAgent:
             json.dump(data, f, ensure_ascii=False, indent=2)
         return data["timestamp"]
 
+    def log_success(
+        self,
+        agent: str,
+        action: str,
+        *,
+        price: float,
+        strategy: str,
+        return_rate: float,
+    ) -> None:
+        """Record a successful trade action."""
+
+        self.log_event(
+            {
+                "agent": agent,
+                "action": action,
+                "price": price,
+                "strategy": strategy,
+                "return_rate": round(return_rate, 4),
+            }
+        )
+
     def log(
         self,
         agent,

--- a/src/agents/risk_manager.py
+++ b/src/agents/risk_manager.py
@@ -1,10 +1,27 @@
 class RiskManager:
-    """Adjust order amounts based on volatility and manage exposure."""
+    """Manage position sizing and stop loss logic."""
 
-    def __init__(self, max_trade_pct: float = 0.1) -> None:
-        self.max_trade_pct = max_trade_pct
+    def __init__(self, max_risk_pct: float = 0.1) -> None:
+        self.max_risk_pct = max_risk_pct
 
-    def order_amount(self, balance: float, volatility: float) -> float:
-        """Return recommended order amount."""
-        factor = max(0.5, 1 - volatility * 50)
-        return balance * self.max_trade_pct * factor
+    def calculate_order_amount(
+        self,
+        balance: float,
+        current_price: float,
+        volatility: float | None = None,
+    ) -> float:
+        """Return an order amount based on account balance and volatility."""
+
+        base_amount = balance * self.max_risk_pct
+        if volatility:
+            adjusted = base_amount * (0.5 if volatility > 0.05 else 1.0)
+            return round(adjusted, 2)
+        return round(base_amount, 2)
+
+    def check_stop_loss(
+        self, entry_price: float, current_price: float, threshold: float = 0.02
+    ) -> bool:
+        """Return ``True`` if the stop-loss threshold is breached."""
+
+        loss_rate = (entry_price - current_price) / entry_price
+        return loss_rate >= threshold

--- a/src/agents/strategy_selector.py
+++ b/src/agents/strategy_selector.py
@@ -4,6 +4,7 @@ class StrategySelector:
     def __init__(self):
         self.current_strategy = None
         self.strategy_mode = "HOLD"
+        self.market_phase = "NEUTRAL"
         self.strategy_scores = {
             "reversal": 1.0,
             "swing": 1.0,
@@ -11,6 +12,16 @@ class StrategySelector:
             "momentum": 1.0,
             "take_profit": 1.0,
         }
+
+    def update_market_phase(self, rsi, bb_score):
+        """Update internal market phase state from RSI and BB score."""
+
+        if rsi < 30:
+            self.market_phase = "FEAR"
+        elif rsi > 85:
+            self.market_phase = "GREED"
+        else:
+            self.market_phase = "NEUTRAL"
 
     def update_scores(self, weights):
         """Update internal strategy scores from learning agent."""
@@ -24,6 +35,12 @@ class StrategySelector:
         import math
         import random
 
+        if isinstance(sentiment, dict):
+            self.update_market_phase(sentiment.get("rsi", 50), sentiment.get("bb_score", 0))
+            sentiment_level = sentiment.get("level", "NEUTRAL")
+        else:
+            sentiment_level = sentiment
+
         mapping = {
             "EXTREME_FEAR": [],
             "FEAR": ["swing"],
@@ -31,11 +48,22 @@ class StrategySelector:
             "GREED": ["trend_follow", "reversal"],
             "EXTREME_GREED": ["reversal", "take_profit"],
         }
-        candidates = mapping.get(sentiment, list(self.strategy_scores.keys()))
+        candidates = mapping.get(sentiment_level, list(self.strategy_scores.keys()))
         candidate_scores = {k: self.strategy_scores.get(k, 1.0) for k in candidates}
         if not candidate_scores:
             self.strategy_mode = "HOLD"
             return "hold", {"weight": 1.0}, 0.0
+
+        preferred = None
+        if self.market_phase == "FEAR":
+            preferred = "reversal"
+        elif self.market_phase == "GREED":
+            preferred = "reversal"
+        else:
+            preferred = "momentum"
+
+        if preferred in candidate_scores:
+            candidate_scores = {preferred: candidate_scores[preferred]}
 
         tau = 0.2
         exp_scores = {k: math.exp(v / tau) for k, v in candidate_scores.items()}


### PR DESCRIPTION
## Summary
- implement `RiskManager` with position sizing and stop loss helpers
- enhance `StrategySelector` with market phase logic and preferred strategy handling
- add logger helper for successful trade events
- apply risk checks and phase updates in `main.py`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842e08b4d9c832087223012e97e82c6