### PR TITLE
Implement score-based entry override

### DIFF
--- a/tests/test_entry_decision.py
+++ b/tests/test_entry_decision.py
@@ -52,3 +52,11 @@ def test_nearest_failed_condition():
     assert nf["passed"] is False
     assert nf["diff"] == pytest.approx(-0.83, abs=0.1)
 
+
+def test_decide_entry_override():
+    agent = EntryDecisionAgent()
+    agent.failed_conditions = ["orderbook_bias_up"]
+    allow, reason = agent.decide_entry("BUY", "INSUFFICIENT_CONDITION_SCORE", 72)
+    assert allow is True
+    assert reason == "high_score_override"
+


### PR DESCRIPTION
## Summary
- add score-based override rules to `EntryDecisionAgent`
- store failed conditions during evaluation
- expose `decide_entry` helper to handle overrides
- apply override logic in `main` and record reason
- test the new `decide_entry` behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842e4747d5083208b985d51b9d548b0