### PR TITLE
Implement hold miss tracking

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 import time
 import os
 import sys
+from datetime import datetime
 
 # Ensure the src package is available for imports when running this file
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "src"))
@@ -18,6 +19,7 @@ from agents.risk_manager import RiskManager
 from agents.emotion_axis import EmotionAxis
 from agents.logger_agent import LoggerAgent
 from agents.learning_agent import LearningAgent
+from agents.missed_hold_tracker import track_failed_hold
 from agents.utils import get_upbit_candles, get_upbit_orderbook
 from status_server import start_status_server, update_state
 from log_analyzer import load_logs, analyze_logs
@@ -99,6 +101,13 @@ class TradingApp:
             confidence = None
         score_percent = self.entry_agent.last_score_percent
         self.last_signal = signal
+        decision_info = {
+            "timestamp": datetime.now().isoformat(),
+            "confidence": score_percent,
+            "action": signal,
+        }
+        if signal == "HOLD":
+            track_failed_hold(decision_info, self.current_price, SYMBOL)
 
         # update weights based on signal quality
         self.learning_agent.adjust_from_signal(strategy, score_percent, confidence)

--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -8,6 +8,7 @@ from .logger_agent import LoggerAgent
 from .learning_agent import LearningAgent
 from .daily_logger import DailyLogger
 from .session_logger import SessionLogger
+from .missed_hold_tracker import track_failed_hold
 
 __all__ = [
     'MarketSentimentAgent',
@@ -20,4 +21,5 @@ __all__ = [
     'SessionLogger',
     'LearningAgent',
     'DailyLogger',
+    'track_failed_hold',
 ]

--- a/src/agents/missed_hold_tracker.py
+++ b/src/agents/missed_hold_tracker.py
@@ -1,0 +1,75 @@
+import asyncio
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Callable
+
+
+ANALYSIS_DELAY_SEC = 5 * 60  # 5 minutes
+THRESHOLD_PCT = 1.0
+MIN_CONFIDENCE = 50.0
+
+LOG_DIR = Path(r"C:\Users\kanur\log\missed_hold")
+LOG_FILE = LOG_DIR / "failed_holds.jsonl"
+
+
+def _default_price_fetcher(symbol: str) -> float:
+    """Fetch the latest closing price for the given symbol."""
+    from .utils import get_upbit_candles
+
+    return get_upbit_candles(symbol, 1)[-1]
+
+
+async def _check_after_delay(
+    decision_info: dict,
+    price_at_decision: float,
+    symbol: str,
+    fetcher: Callable[[str], float],
+) -> None:
+    await asyncio.sleep(ANALYSIS_DELAY_SEC)
+    try:
+        price_after = fetcher(symbol)
+    except Exception:
+        return
+
+    change_pct = (price_after - price_at_decision) / price_at_decision * 100
+    if (
+        change_pct > THRESHOLD_PCT
+        and decision_info.get("confidence", 0.0) >= MIN_CONFIDENCE
+    ):
+        entry = {
+            "symbol": symbol,
+            "timestamp": decision_info.get("timestamp", datetime.now().isoformat()),
+            "confidence": decision_info.get("confidence"),
+            "price_at_decision": price_at_decision,
+            "price_after_5min": price_after,
+            "price_change_pct": round(change_pct, 2),
+            "verdict": "MISSED_BUY_OPPORTUNITY",
+        }
+        LOG_DIR.mkdir(parents=True, exist_ok=True)
+        with open(LOG_FILE, "a", encoding="utf-8") as f:
+            f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+
+
+def track_failed_hold(
+    decision_info: dict,
+    current_price: float,
+    symbol: str,
+    *,
+    price_fetcher: Callable[[str], float] | None = None,
+) -> None:
+    """Schedule a check to log missed opportunities after a HOLD decision."""
+    if decision_info.get("action") != "HOLD":
+        return
+
+    fetcher = price_fetcher or _default_price_fetcher
+
+    async def runner() -> None:
+        await _check_after_delay(decision_info, current_price, symbol, fetcher)
+
+    loop = asyncio.get_event_loop()
+    if loop.is_running():
+        loop.create_task(runner())
+    else:
+        asyncio.get_event_loop().run_in_executor(None, asyncio.run, runner())
+


### PR DESCRIPTION
## Summary
- detect missed opportunities when HOLD is returned
- schedule a background price check to log failed HOLD decisions
- expose new helper from agents package and call it in main

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6843728112f083209478a9e240127d53