### PR TITLE
Add strategy scorer for weighted scoring and centralize log paths

### DIFF
--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -9,6 +9,7 @@ from .learning_agent import LearningAgent
 from .daily_logger import DailyLogger
 from .session_logger import SessionLogger
 from .missed_hold_tracker import track_failed_hold
+from .strategy_scorer import StrategyScorer
 
 __all__ = [
     'MarketSentimentAgent',
@@ -22,4 +23,5 @@ __all__ = [
     'LearningAgent',
     'DailyLogger',
     'track_failed_hold',
+    'StrategyScorer',
 ]

--- a/src/agents/daily_logger.py
+++ b/src/agents/daily_logger.py
@@ -8,8 +8,8 @@ class DailyLogger:
     """Simple logger that appends success and failure events by day."""
 
     def __init__(self, base_dir: str | os.PathLike | None = None):
-        desktop = Path.home() / "Desktop" if base_dir is None else Path(base_dir)
-        self.log_dir = desktop / "NOVA_LOGS"
+        base = Path(base_dir) if base_dir is not None else Path(r"C:/Users/kanur/log")
+        self.log_dir = base / "NOVA_LOGS"
         self.log_dir.mkdir(parents=True, exist_ok=True)
 
     def _get_log_file(self, kind: str) -> Path:

--- a/src/agents/entry_decision.py
+++ b/src/agents/entry_decision.py
@@ -1,8 +1,12 @@
+from .strategy_scorer import StrategyScorer
+
+
 class EntryDecisionAgent:
     """Determine trade entry signals for various strategies."""
 
     def __init__(self):
         self.last_score_percent = 0.0
+        self.scorer = StrategyScorer()
         self.nearest_failed = None
         self.failed_conditions = []
         self.override_rules = {
@@ -103,7 +107,9 @@ class EntryDecisionAgent:
         else:
             self.nearest_failed = None
 
-        self.last_score_percent = sum(bool(v) for v in condition_scores.values()) / len(condition_scores) * 100
+        self.last_score_percent = self.scorer.score(condition_scores)
+        if failed_conditions:
+            self.scorer.tune_weights(failed_conditions.keys())
 
         if logger is not None:
             logger.log_event({

--- a/src/agents/missed_hold_tracker.py
+++ b/src/agents/missed_hold_tracker.py
@@ -9,7 +9,7 @@ ANALYSIS_DELAY_SEC = 5 * 60  # 5 minutes
 THRESHOLD_PCT = 1.0
 MIN_CONFIDENCE = 50.0
 
-LOG_DIR = Path(r"C:\Users\kanur\log\missed_hold")
+LOG_DIR = Path(r"C:/Users/kanur/log/missed_hold")
 LOG_FILE = LOG_DIR / "failed_holds.jsonl"
 
 

--- a/src/agents/session_logger.py
+++ b/src/agents/session_logger.py
@@ -7,8 +7,8 @@ class SessionLogger:
     """Unified logger that appends entries to a single file per session."""
 
     def __init__(self, base_dir: str | Path | None = None):
-        desktop_path = Path.home() / "Desktop" if base_dir is None else Path(base_dir)
-        self.log_dir = desktop_path / "NOVA_LOGS"
+        base = Path(base_dir) if base_dir is not None else Path(r"C:/Users/kanur/log")
+        self.log_dir = base / "NOVA_LOGS"
         self.log_dir.mkdir(parents=True, exist_ok=True)
         session_id = datetime.now().strftime("%Y%m%d_%H%M%S")
         self.log_file = self.log_dir / f"trade_log_{session_id}.json"

--- a/src/agents/strategy_scorer.py
+++ b/src/agents/strategy_scorer.py
@@ -1,0 +1,58 @@
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Iterable
+
+DEFAULT_WEIGHTS: Dict[str, float] = {
+    "rsi_above_55": 0.25,
+    "ma_cross": 0.2,
+    "golden_cross": 0.25,
+    "orderbook_bias_up": 0.15,
+    "volatility_threshold": 0.15,
+}
+
+
+class StrategyScorer:
+    """Compute weighted condition scores and tune weights from failures."""
+
+    def __init__(
+        self,
+        weights: Dict[str, float] | None = None,
+        *,
+        log_dir: str | Path | None = None,
+        history_file: str = "weight_changes.jsonl",
+    ) -> None:
+        self.weights: Dict[str, float] = dict(DEFAULT_WEIGHTS)
+        if weights:
+            self.weights.update(weights)
+        base = Path(log_dir) if log_dir is not None else Path(r"C:/Users/kanur/log/strategy_scorer")
+        base.mkdir(parents=True, exist_ok=True)
+        self.log_dir = base
+        self.history_path = base / history_file
+
+    def score(self, conditions: Dict[str, bool]) -> float:
+        """Return overall score percentage from condition pass map."""
+        total = 0.0
+        for name, passed in conditions.items():
+            if passed:
+                total += self.weights.get(name, 0.0)
+        return total * 100
+
+    def tune_weights(self, failed: Iterable[str], alpha: float = 0.1) -> None:
+        """Soft-update weights based on failed condition names."""
+        updates: Dict[str, Dict[str, float]] = {}
+        for cond in failed:
+            if cond not in self.weights:
+                continue
+            old = self.weights[cond]
+            new = max(0.0, old * (1 - alpha))
+            if new != old:
+                self.weights[cond] = new
+                updates[cond] = {"old": old, "new": new}
+        if updates:
+            self._record_updates(updates)
+
+    def _record_updates(self, updates: Dict[str, Dict[str, float]]) -> None:
+        entry = {"timestamp": datetime.utcnow().isoformat(), "updates": updates}
+        with open(self.history_path, "a", encoding="utf-8") as f:
+            f.write(json.dumps(entry, ensure_ascii=False) + "\n")


### PR DESCRIPTION
## Summary
- introduce `StrategyScorer` for weighted condition scoring and soft updates
- use `StrategyScorer` in `EntryDecisionAgent`
- store weight change history under `C:/Users/kanur/log/strategy_scorer`
- change default directories of `DailyLogger`, `SessionLogger`, and `missed_hold_tracker` to the central log folder
- export `StrategyScorer` from `agents`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68438d4f261883208d0dee9a7dd764e5