### PR TITLE
Implement strategy generation and evaluation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ Thumbs.db
 
 __pycache__/
 *.pyc
+data/
+C:

--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -6,6 +6,8 @@ from .risk_manager import RiskManager
 from .emotion_axis import EmotionAxis
 from .logger_agent import LoggerAgent
 from .learning_agent import LearningAgent
+from .strategy_generator import StrategyGenerator
+from .strategy_evaluator import StrategyEvaluator
 from .daily_logger import DailyLogger
 from .session_logger import SessionLogger
 from .missed_hold_tracker import track_failed_hold
@@ -21,6 +23,8 @@ __all__ = [
     'LoggerAgent',
     'SessionLogger',
     'LearningAgent',
+    'StrategyGenerator',
+    'StrategyEvaluator',
     'DailyLogger',
     'track_failed_hold',
     'StrategyScorer',

--- a/src/agents/learning_agent.py
+++ b/src/agents/learning_agent.py
@@ -1,44 +1,93 @@
+import json
 import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
 
 
 class LearningAgent:
-    """Agent that updates strategy weights based on performance."""
+    """Persistently learn strategy weights from trade history."""
 
-    def __init__(self):
-        self.weights = {}
-        self.history = []
+    def __init__(self, state_path: str | Path | None = None) -> None:
+        self.state_path = Path(state_path) if state_path else Path("data/learning_state.json")
+        self.weights: Dict[str, float] = {}
+        self.history: List[Dict[str, Any]] = []
+        self._load()
 
-    def record_trade(self, strategy: str, return_rate: float) -> None:
-        """Store trade result for later evaluation."""
+    # ------------------------------------------------------------------
+    def _load(self) -> None:
+        try:
+            with open(self.state_path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            self.weights = data.get("weights", {})
+            self.history = data.get("history", [])
+        except FileNotFoundError:
+            self.weights = {}
+            self.history = []
+
+    def _save(self) -> None:
+        self.state_path.parent.mkdir(parents=True, exist_ok=True)
+        data = {"weights": self.weights, "history": self.history}
+        with open(self.state_path, "w", encoding="utf-8") as f:
+            json.dump(data, f, ensure_ascii=False, indent=2)
+
+    def record_trade(
+        self,
+        strategy: str,
+        return_rate: float,
+        market_phase: str | None = None,
+        emotion_score: float | None = None,
+        risk: float | None = None,
+    ) -> None:
+        """Store trade result with additional context."""
         self.history.append(
             {
                 "strategy": strategy,
                 "return": return_rate,
+                "market_phase": market_phase,
+                "emotion": emotion_score,
+                "risk": risk,
                 "timestamp": time.time(),
             }
         )
+        self._save()
 
-    def update(self, trade_history=None):
-        """Update strategy weights using recent one week of trades."""
+    def update(self, trade_history: Optional[List[Dict[str, Any]]] = None) -> Dict[str, float]:
+        """Update strategy weights using the last month of trades."""
 
-        if trade_history is None:
-            trade_history = self.history
+        history = trade_history if trade_history is not None else self.history
+        one_month_ago = time.time() - 30 * 24 * 3600
+        recent = [t for t in history if t.get("timestamp", 0) >= one_month_ago]
 
-        one_week_ago = time.time() - 7 * 24 * 3600
-        recent = [t for t in trade_history if t.get("timestamp", 0) >= one_week_ago]
-
-        alpha = 0.3
+        grouped: Dict[str, List[Dict[str, Any]]] = {}
         for trade in recent:
-            name = trade.get("strategy")
-            ret = trade.get("return", 0)
-            old = self.weights.get(name, 1.0)
-            self.weights[name] = old + alpha * ret
+            grouped.setdefault(trade.get("strategy"), []).append(trade)
 
-        # remove strategies with consistently negative weights
-        for name, weight in list(self.weights.items()):
-            if weight < -1:
+        for name, trades in grouped.items():
+            rets = [t.get("return", 0.0) for t in trades]
+            avg_ret = sum(rets) / len(rets)
+            trend = sum(1 if r > 0 else -1 for r in rets[-3:])
+
+            phase_counts: Dict[str, int] = {}
+            for t in trades:
+                phase = t.get("market_phase")
+                if phase:
+                    phase_counts[phase] = phase_counts.get(phase, 0) + 1
+            phase_ratio = 0.0
+            if phase_counts:
+                phase_ratio = max(phase_counts.values()) / len(trades)
+
+            emotion = sum(t.get("emotion", 0.0) for t in trades) / len(trades)
+
+            score = avg_ret + 0.1 * trend + 0.1 * emotion + 0.5 * phase_ratio
+            old = self.weights.get(name, 1.0)
+            self.weights[name] = old * 0.9 + score * 0.1
+
+        # purge consistently poor strategies
+        for name in list(self.weights.keys()):
+            if self.weights[name] < -1:
                 del self.weights[name]
 
+        self._save()
         return self.weights
 
     def adjust_from_signal(self, strategy: str, score_percent: float, confidence: float | None) -> None:
@@ -47,3 +96,5 @@ class LearningAgent:
         weight = self.weights.get(strategy, 1.0)
         weight += 0.01 * (score_percent / 100.0) * conf
         self.weights[strategy] = weight
+        self._save()
+

--- a/src/agents/strategy_evaluator.py
+++ b/src/agents/strategy_evaluator.py
@@ -1,0 +1,74 @@
+import statistics
+from typing import Any, Dict, Iterable, List, Tuple
+
+
+class StrategyEvaluator:
+    """Compute performance metrics for generated strategies."""
+
+    def __init__(self) -> None:
+        pass
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _max_drawdown(returns: Iterable[float]) -> float:
+        cum = 0.0
+        peak = 0.0
+        max_dd = 0.0
+        for r in returns:
+            cum += r
+            peak = max(peak, cum)
+            dd = peak - cum
+            max_dd = max(max_dd, dd)
+        return max_dd
+
+    def _sqn(self, returns: List[float]) -> float:
+        if len(returns) < 2:
+            return 0.0
+        avg = statistics.mean(returns)
+        std = statistics.stdev(returns)
+        if std == 0:
+            return 0.0
+        return (avg / std) * (len(returns) ** 0.5)
+
+    # ------------------------------------------------------------------
+    def market_fit(self, trades: Iterable[Dict[str, Any]]) -> Tuple[str, float]:
+        counts: Dict[str, int] = {}
+        total = 0
+        for t in trades:
+            phase = t.get("market_phase")
+            if not phase:
+                continue
+            counts[phase] = counts.get(phase, 0) + 1
+            total += 1
+        if not counts or total == 0:
+            return "UNKNOWN", 0.0
+        best = max(counts, key=counts.get)
+        ratio = counts[best] / total
+        return best, ratio
+
+    def mfe_mae(self, trades: Iterable[Dict[str, Any]]) -> Tuple[float, float]:
+        mfes: List[float] = []
+        maes: List[float] = []
+        for t in trades:
+            mfes.append(t.get("max_profit", 0.0))
+            maes.append(t.get("max_loss", 0.0))
+        avg_mfe = statistics.mean(mfes) if mfes else 0.0
+        avg_mae = statistics.mean(maes) if maes else 0.0
+        return avg_mfe, avg_mae
+
+    def evaluate(self, returns: List[float], trades: List[Dict[str, Any]]) -> Dict[str, Any]:
+        """Return evaluation metrics for a strategy."""
+        total_return = sum(returns)
+        max_dd = self._max_drawdown(returns)
+        sqn = self._sqn(returns)
+        phase, fit_ratio = self.market_fit(trades)
+        avg_mfe, avg_mae = self.mfe_mae(trades)
+        return {
+            "total_return": total_return,
+            "max_drawdown": max_dd,
+            "sqn": sqn,
+            "market_fit": phase,
+            "fit_ratio": fit_ratio,
+            "avg_mfe": avg_mfe,
+            "avg_mae": avg_mae,
+        }

--- a/src/agents/strategy_generator.py
+++ b/src/agents/strategy_generator.py
@@ -1,0 +1,111 @@
+import json
+import random
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+class StrategyGenerator:
+    """Generate and evolve simple trading strategy definitions."""
+
+    def __init__(self, *, seed: Optional[int] = None) -> None:
+        self.rng = random.Random(seed)
+        self.generated: List[Dict[str, Any]] = []
+
+    # condition builders -------------------------------------------------
+    def _ma_condition(self) -> Dict[str, Any]:
+        period = self.rng.choice([5, 10, 20, 30, 60])
+        direction = self.rng.choice([">", "<"])
+        return {"type": "MA", "period": period, "direction": direction}
+
+    def _rsi_condition(self) -> Dict[str, Any]:
+        period = self.rng.choice([14, 20])
+        level = self.rng.choice([30, 45, 55, 70])
+        op = self.rng.choice([">", "<"])
+        return {"type": "RSI", "period": period, "level": level, "op": op}
+
+    def _macd_condition(self) -> Dict[str, Any]:
+        fast = self.rng.choice([12, 26])
+        slow = self.rng.choice([26, 52])
+        signal = self.rng.choice([9, 12])
+        return {"type": "MACD", "fast": fast, "slow": slow, "signal": signal}
+
+    # generation ---------------------------------------------------------
+    def create_strategy(self) -> Dict[str, Any]:
+        """Return a randomly generated strategy dictionary."""
+        conds = []
+        for _ in range(self.rng.randint(1, 3)):
+            builder = self.rng.choice(
+                [self._ma_condition, self._rsi_condition, self._macd_condition]
+            )
+            conds.append(builder())
+        strat = {"id": f"gen_{len(self.generated)}", "conditions": conds}
+        self.generated.append(strat)
+        return strat
+
+    # evolutionary operations -------------------------------------------
+    def mutate(self, strategy: Dict[str, Any]) -> Dict[str, Any]:
+        new = json.loads(json.dumps(strategy))
+        if new.get("conditions"):
+            idx = self.rng.randrange(len(new["conditions"]))
+            cond = new["conditions"][idx]
+            if cond["type"] == "MA":
+                cond["period"] = max(2, cond["period"] + self.rng.choice([-5, 5]))
+            elif cond["type"] == "RSI":
+                cond["level"] = min(100, max(0, cond["level"] + self.rng.choice([-5, 5])))
+            elif cond["type"] == "MACD":
+                cond["signal"] = max(1, cond["signal"] + self.rng.choice([-1, 1]))
+        new["id"] = f"gen_{len(self.generated)}"
+        self.generated.append(new)
+        return new
+
+    def crossover(self, a: Dict[str, Any], b: Dict[str, Any]) -> Dict[str, Any]:
+        """Create a new strategy by combining two parents."""
+        ac = a.get("conditions", [])
+        bc = b.get("conditions", [])
+        pivot_a = self.rng.randint(0, len(ac)) if ac else 0
+        pivot_b = self.rng.randint(0, len(bc)) if bc else 0
+        conds = ac[:pivot_a] + bc[pivot_b:]
+        if not conds:
+            return self.mutate(a if self.rng.random() < 0.5 else b)
+        strat = {"id": f"gen_{len(self.generated)}", "conditions": conds}
+        self.generated.append(strat)
+        return strat
+
+    def evolve(
+        self,
+        strategies: List[Dict[str, Any]],
+        performance: List[float],
+        *,
+        mutation_rate: float = 0.2,
+    ) -> List[Dict[str, Any]]:
+        """Return evolved strategies using simple selection logic."""
+        if not strategies:
+            return []
+        paired = list(zip(strategies, performance))
+        paired.sort(key=lambda x: x[1], reverse=True)
+        parents = [s for s, _ in paired[: max(1, len(paired) // 2)]]
+        children = []
+        for _ in range(len(strategies)):
+            if self.rng.random() < mutation_rate:
+                base = self.rng.choice(parents)
+                children.append(self.mutate(base))
+            else:
+                a, b = self.rng.sample(parents, k=2) if len(parents) >= 2 else (parents[0], parents[0])
+                children.append(self.crossover(a, b))
+        return children
+
+    # persistence --------------------------------------------------------
+    def save(self, path: str | Path) -> None:
+        data = {"strategies": self.generated}
+        Path(path).parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(data, f, ensure_ascii=False, indent=2)
+
+    def load(self, path: str | Path) -> List[Dict[str, Any]]:
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            self.generated = data.get("strategies", [])
+        except FileNotFoundError:
+            self.generated = []
+        return self.generated

--- a/tests/test_learning_agent_adv.py
+++ b/tests/test_learning_agent_adv.py
@@ -1,0 +1,17 @@
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
+from agents.learning_agent import LearningAgent
+
+
+def test_learning_agent_update(tmp_path):
+    state = tmp_path / 'state.json'
+    agent = LearningAgent(state_path=state)
+    agent.record_trade('s1', 0.1, market_phase='TREND', emotion_score=0.5, risk=0.1)
+    agent.record_trade('s1', 0.05, market_phase='TREND', emotion_score=0.4, risk=0.1)
+    weights = agent.update()
+    assert 's1' in weights
+    assert weights['s1'] > 0
+

--- a/tests/test_strategy_evaluator.py
+++ b/tests/test_strategy_evaluator.py
@@ -1,0 +1,19 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
+from agents.strategy_evaluator import StrategyEvaluator
+
+
+def test_evaluate_metrics():
+    evaluator = StrategyEvaluator()
+    returns = [0.1, -0.05, 0.2]
+    trades = [
+        {'market_phase': 'TREND', 'max_profit': 0.12, 'max_loss': -0.04},
+        {'market_phase': 'TREND', 'max_profit': 0.2, 'max_loss': -0.05},
+    ]
+    res = evaluator.evaluate(returns, trades)
+    assert res['total_return'] == pytest.approx(0.25)
+    assert res['market_fit'] == 'TREND'
+

--- a/tests/test_strategy_generator.py
+++ b/tests/test_strategy_generator.py
@@ -1,0 +1,13 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
+from agents.strategy_generator import StrategyGenerator
+
+
+def test_create_strategy():
+    gen = StrategyGenerator(seed=42)
+    strat = gen.create_strategy()
+    assert 'conditions' in strat
+    assert isinstance(strat['conditions'], list)
+    assert strat['id'].startswith('gen_')


### PR DESCRIPTION
## Summary
- add strategy generation system for evolving trading rules
- create evaluator computing returns, drawdown, SQN and fit metrics
- overhaul learning agent with persistent state and richer update logic
- export new modules and add tests
- ignore generated data

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68439245f3348320a730ddd1812c9d11