### PR TITLE
Switch log defaults to Path.home

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ a simple web dashboard built using Flask. The agents demonstrate the following r
 - **StrategySelector**: chooses a trading strategy based on sentiment.
 - **EntryDecisionAgent**: decides whether to buy, sell, or hold.
 - **PositionManager**: evaluates open positions for exit conditions.
-- **LoggerAgent**: appends agent activity to a daily `log_YYYYMMDD.jsonl` file under `C:/Users/kanur/log`.
-- **DailyLogger**: appends daily success and failure entries in `NOVA_LOGS` on your Desktop.
-- **SessionLogger**: writes all actions for a single run to `NOVA_LOGS/trade_log_<timestamp>.json`.
+- **LoggerAgent**: appends agent activity to a daily `log_YYYYMMDD.jsonl` file in `~/log` by default.
+- **DailyLogger**: appends daily success and failure entries in `~/NOVA_LOGS` by default.
+- **SessionLogger**: writes all actions for a single run to `~/NOVA_LOGS/trade_log_<timestamp>.json`.
 - **Flask Status Server**: serves a web dashboard and JSON API.
 - **LearningAgent**: placeholder for future strategy learning.
 

--- a/src/agents/daily_logger.py
+++ b/src/agents/daily_logger.py
@@ -8,7 +8,7 @@ class DailyLogger:
     """Simple logger that appends success and failure events by day."""
 
     def __init__(self, base_dir: str | os.PathLike | None = None):
-        base = Path(base_dir) if base_dir is not None else Path(r"C:/Users/kanur/log")
+        base = Path(base_dir) if base_dir else Path.home()
         self.log_dir = base / "NOVA_LOGS"
         self.log_dir.mkdir(parents=True, exist_ok=True)
 

--- a/src/agents/logger_agent.py
+++ b/src/agents/logger_agent.py
@@ -3,7 +3,7 @@ import threading
 from pathlib import Path
 from datetime import datetime
 
-LOG_DIR = Path(r"C:/Users/kanur/log")
+LOG_DIR = Path.home() / "log"
 _lock = threading.Lock()
 
 

--- a/src/agents/missed_hold_tracker.py
+++ b/src/agents/missed_hold_tracker.py
@@ -9,7 +9,7 @@ ANALYSIS_DELAY_SEC = 5 * 60  # 5 minutes
 THRESHOLD_PCT = 1.0
 MIN_CONFIDENCE = 50.0
 
-LOG_DIR = Path(r"C:/Users/kanur/log/missed_hold")
+LOG_DIR = Path.home() / "log" / "missed_hold"
 LOG_FILE = LOG_DIR / "failed_holds.jsonl"
 
 

--- a/src/agents/session_logger.py
+++ b/src/agents/session_logger.py
@@ -7,7 +7,7 @@ class SessionLogger:
     """Unified logger that appends entries to a single file per session."""
 
     def __init__(self, base_dir: str | Path | None = None):
-        base = Path(base_dir) if base_dir is not None else Path(r"C:/Users/kanur/log")
+        base = Path(base_dir) if base_dir else Path.home()
         self.log_dir = base / "NOVA_LOGS"
         self.log_dir.mkdir(parents=True, exist_ok=True)
         session_id = datetime.now().strftime("%Y%m%d_%H%M%S")

--- a/src/agents/strategy_scorer.py
+++ b/src/agents/strategy_scorer.py
@@ -25,7 +25,7 @@ class StrategyScorer:
         self.weights: Dict[str, float] = dict(DEFAULT_WEIGHTS)
         if weights:
             self.weights.update(weights)
-        base = Path(log_dir) if log_dir is not None else Path(r"C:/Users/kanur/log/strategy_scorer")
+        base = Path(log_dir) if log_dir else Path.home() / "log" / "strategy_scorer"
         base.mkdir(parents=True, exist_ok=True)
         self.log_dir = base
         self.history_path = base / history_file


### PR DESCRIPTION
## Summary
- change default log locations to use `Path.home()`
- update README examples

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684399ed597483209638292b3870fcfa