### PR TITLE
Remove empty __init__

### DIFF
--- a/src/agents/strategy_evaluator.py
+++ b/src/agents/strategy_evaluator.py
@@ -5,9 +5,6 @@ from typing import Any, Dict, Iterable, List, Tuple
 class StrategyEvaluator:
     """Compute performance metrics for generated strategies."""
 
-    def __init__(self) -> None:
-        pass
-
     # ------------------------------------------------------------------
     @staticmethod
     def _max_drawdown(returns: Iterable[float]) -> float:


### PR DESCRIPTION
## Summary
- simplify `StrategyEvaluator` by removing an unnecessary empty constructor

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684399f1ab5c8320a19312f46457569d