### PR TITLE
Remove unused current_price from RiskManager

### DIFF
--- a/main.py
+++ b/main.py
@@ -122,7 +122,7 @@ class TradingApp:
 
         if allow_entry and can_enter_trade(self.positions):
             order_amount = self.risk.calculate_order_amount(
-                self.balance, self.current_price, volatility
+                self.balance, volatility
             )
             if order_amount > 0:
                 qty = order_amount / self.current_price

--- a/src/agents/risk_manager.py
+++ b/src/agents/risk_manager.py
@@ -7,7 +7,6 @@ class RiskManager:
     def calculate_order_amount(
         self,
         balance: float,
-        current_price: float,
         volatility: float | None = None,
     ) -> float:
         """Return an order amount based on account balance and volatility."""


### PR DESCRIPTION
## Summary
- update `RiskManager.calculate_order_amount` to drop `current_price`
- pass balance and volatility only when calculating order size in `TradingApp`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684399f0f5b48320bc54609aecde84fe