### PR TITLE
Add conflict index logging

### DIFF
--- a/main.py
+++ b/main.py
@@ -131,6 +131,7 @@ class TradingApp:
             human_likely_action=human_action,
             score_vs_human=score_vs_human,
             strategy_version=STRATEGY_VERSION,
+            conflict_analysis=self.entry_agent.last_conflict,
         )
 
         allow_entry, entry_reason = self.entry_agent.decide_entry(signal, reason, score_percent)

--- a/src/agents/logger_agent.py
+++ b/src/agents/logger_agent.py
@@ -124,6 +124,7 @@ class LoggerAgent:
         strategy_version: str,
         result_after_5min: float | None = None,
         result_after_30min: float | None = None,
+        conflict_analysis: dict | None = None,
     ) -> None:
         entry = {
             "time": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
@@ -136,6 +137,7 @@ class LoggerAgent:
             "strategy_version": strategy_version,
             "result_after_5min": result_after_5min,
             "result_after_30min": result_after_30min,
+            "conflict_analysis": conflict_analysis,
         }
 
         path = self._judgment_file_for_today()

--- a/tests/test_entry_decision.py
+++ b/tests/test_entry_decision.py
@@ -60,3 +60,13 @@ def test_decide_entry_override():
     assert allow is True
     assert reason == "high_score_override"
 
+
+def test_conflict_index_detection():
+    agent = EntryDecisionAgent()
+    chart = [1] * 21 + [2] * 5
+    order_book = {"bid_volume": 1, "ask_volume": 10, "bids": [], "asks": []}
+    signal = agent.evaluate("momentum", chart, None, order_book)
+    assert signal == "BUY"
+    ci = agent.last_conflict["conflict_index"]
+    assert ci >= 0.5
+

--- a/tests/test_logger_judgment.py
+++ b/tests/test_logger_judgment.py
@@ -18,6 +18,7 @@ def test_log_judgment(tmp_path):
         human_likely_action='HOLD',
         score_vs_human=0,
         strategy_version='v1',
+        conflict_analysis={'conflict_index': 0.5, 'conflict_factors': []},
     )
     date_str = Path(logger._judgment_file_for_today()).name
     path = tmp_path / '판단로그' / date_str
@@ -26,3 +27,4 @@ def test_log_judgment(tmp_path):
         data = json.loads(f.readline())
     assert data['action'] == 'BUY'
     assert data['strategy_version'] == 'v1'
+    assert 'conflict_analysis' in data


### PR DESCRIPTION
## Summary
- compute conflict index in EntryDecisionAgent
- log conflict analysis in LoggerAgent
- expose conflict info in main loop
- test conflict index detection and judgment logging

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843a0f536788320be65bce5975fbcbd