### PR TITLE
Add customizable dashboard theme

### DIFF
--- a/static/status.js
+++ b/static/status.js
@@ -23,6 +23,43 @@ function updateReturnTable(positions, currentPrice) {
     });
 }
 
+const THEME_PRESETS = {
+    'Dark Insight': 'theme-dark-insight',
+    'Alert Red': 'theme-alert-red',
+    'Calm Green': 'theme-calm-green',
+    'Clarity Blue': 'theme-clarity-blue'
+};
+
+async function loadTheme() {
+    try {
+        const res = await fetch('/api/theme');
+        const data = await res.json();
+        applyTheme(data.theme || 'Dark Insight');
+        const sel = document.getElementById('themeSelect');
+        if (sel) sel.value = data.theme || 'Dark Insight';
+    } catch (e) {
+        applyTheme('Dark Insight');
+    }
+}
+
+function applyTheme(name) {
+    const cls = THEME_PRESETS[name] || THEME_PRESETS['Dark Insight'];
+    document.body.className = cls;
+}
+
+async function setTheme(name) {
+    applyTheme(name);
+    try {
+        await fetch('/api/theme', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ theme: name })
+        });
+    } catch (e) {
+        console.error(e);
+    }
+}
+
 async function refresh() {
     try {
         const res = await fetch('/api/status');
@@ -187,6 +224,7 @@ async function refresh() {
 }
 setInterval(refresh, 1000);
 refresh();
+document.addEventListener('DOMContentLoaded', loadTheme);
 
 function toggleTradeLog() {
     const log = document.getElementById('tradeLog');

--- a/static/styles.css
+++ b/static/styles.css
@@ -41,3 +41,11 @@
 .emotion-공포{background-color:#e74c3c;}
 .emotion-무관심{background-color:#7f8c8d;}
 
+/* Theme definitions */
+body{background-color:var(--bg-color);color:var(--text-color);}
+.box{background-color:var(--box-bg);}
+.theme-dark-insight{--bg-color:#0d1b2a;--box-bg:#1b263b;--text-color:#ffffff;}
+.theme-alert-red{--bg-color:#660708;--box-bg:#370617;--text-color:#ffffff;}
+.theme-calm-green{--bg-color:#014f43;--box-bg:#1d7152;--text-color:#ffffff;}
+.theme-clarity-blue{--bg-color:#003566;--box-bg:#1c3f6b;--text-color:#ffffff;}
+

--- a/templates/status.html
+++ b/templates/status.html
@@ -11,7 +11,17 @@
 <div id="emotionBadge" class="emotion-badge">-</div>
 <section class="section">
 <div class="container">
-    <h1 class="title">트레이딩 현황</h1>
+    <div style="display:flex;justify-content:space-between;align-items:center;">
+      <h1 class="title" style="margin-bottom:0;">트레이딩 현황</h1>
+      <div>
+        <select id="themeSelect" onchange="setTheme(this.value)">
+          <option value="Dark Insight">Dark Insight</option>
+          <option value="Alert Red">Alert Red</option>
+          <option value="Calm Green">Calm Green</option>
+          <option value="Clarity Blue">Clarity Blue</option>
+        </select>
+      </div>
+    </div>
     <h2 class="subtitle" id="selected_strategy">-</h2>
     <div class="columns is-multiline" id="cards">
         <div class="column is-one-third">


### PR DESCRIPTION
## Summary
- implement client-side theme presets with dropdown selector
- store chosen theme in `ui_config.json`
- serve theme config via new `/api/theme` endpoint
- apply theme classes and variables in stylesheets

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843b0231d9483208e0fa277174f8292