### PR TITLE
Add log archiver utility and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,15 @@ python report_server.py
 This will start a Flask app on port `7860` with a `/report` endpoint displaying
 a simple summary.
 
+To keep the log directory tidy, you can archive files older than a day into
+date-stamped zip files:
+
+```bash
+python log_archiver.py
+```
+The script compresses `.jsonl`, `.json`, `.csv`, and `.txt` logs under
+`C:/Users/kanur/log` and removes the originals after archiving.
+
 ## Disclaimer / 면책 조항
 
 **English:** This project is provided for demonstration and educational purposes only. It is not intended as financial advice or a solicitation to trade. Using this code for real trading is done at your own risk, and the authors disclaim all liability for any potential losses.

--- a/log_archiver.py
+++ b/log_archiver.py
@@ -1,0 +1,36 @@
+import os
+import zipfile
+from datetime import datetime
+from pathlib import Path
+
+
+def archive_logs(base_dir: str = r"C:/Users/kanur/log", *, days: int = 1) -> None:
+    """Compress log files older than ``days`` into per-day zip archives.
+
+    Parameters
+    ----------
+    base_dir : str
+        Directory containing log files.
+    days : int, optional
+        Minimum age of files in days before archiving, by default 1.
+    """
+    base = Path(base_dir)
+    if not base.is_dir():
+        raise FileNotFoundError(base)
+
+    now = datetime.now()
+    for file in base.iterdir():
+        if not file.is_file() or file.suffix not in {".json", ".jsonl", ".csv", ".txt"}:
+            continue
+        age = now - datetime.fromtimestamp(file.stat().st_mtime)
+        if age.days < days:
+            continue
+        date_str = datetime.fromtimestamp(file.stat().st_mtime).strftime("%Y-%m-%d")
+        zip_path = base / f"{date_str}.zip"
+        with zipfile.ZipFile(zip_path, "a", zipfile.ZIP_DEFLATED) as zf:
+            zf.write(file, arcname=file.name)
+        file.unlink()
+
+
+if __name__ == "__main__":
+    archive_logs()


### PR DESCRIPTION
## Summary
- add a `log_archiver.py` utility to compress log files into daily zip archives
- document how to use the log archiver in the README

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6843b34f3ad88320974e2366ab05e70a