### PR TITLE
Add RL preprocessing and training scripts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ Flask>=2.2
 requests>=2.0
 matplotlib>=3.5
 pyngrok>=7.0
+torch

--- a/rl_preprocess.py
+++ b/rl_preprocess.py
@@ -1,0 +1,69 @@
+import json
+from pathlib import Path
+from datetime import datetime
+from typing import List, Dict, Any
+
+
+def preprocess_logs(base_dir: str = r"C:/Users/kanur/log") -> Path:
+    """Convert judgment logs into RL format and save to a jsonl file.
+
+    The output file will be named ``nova_rl_data_{YYYY-MM-DD}.jsonl`` under
+    ``강화학습전처리`` inside ``base_dir``.
+    """
+    base_path = Path(base_dir) / "판단기록"
+    out_dir = Path(base_dir) / "강화학습전처리"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    rl_entries: List[Dict[str, Any]] = []
+    files = sorted(base_path.glob("log_*.jsonl"))
+    for file in files:
+        with open(file, encoding="utf-8") as f:
+            raw = [json.loads(line) for line in f if line.strip()]
+        for i, entry in enumerate(raw):
+            state = [
+                entry.get("rsi"),
+                entry.get("ma_diff"),
+                entry.get("volume_ratio"),
+                entry.get("golden_cross_dist"),
+                entry.get("market_emotion_index", 0.0),
+            ]
+            action_map = {"BUY": 1, "SELL": -1, "NONE": 0}
+            action = action_map.get(entry.get("action", "NONE"), 0)
+            change = entry.get("future_return_5m", 0.0)
+            reward = 0
+            if change > 0.015:
+                reward = 1
+            elif change < -0.015:
+                reward = -1
+            next_state = None
+            if i + 1 < len(raw):
+                nxt = raw[i + 1]
+                next_state = [
+                    nxt.get("rsi"),
+                    nxt.get("ma_diff"),
+                    nxt.get("volume_ratio"),
+                    nxt.get("golden_cross_dist"),
+                    nxt.get("market_emotion_index", 0.0),
+                ]
+            done = i + 1 == len(raw)
+            rl_entries.append(
+                {
+                    "state": state,
+                    "action": action,
+                    "reward": reward,
+                    "next_state": next_state,
+                    "done": done,
+                }
+            )
+
+    date_str = datetime.now().strftime("%Y-%m-%d")
+    out_file = out_dir / f"nova_rl_data_{date_str}.jsonl"
+    with open(out_file, "w", encoding="utf-8") as f:
+        for e in rl_entries:
+            f.write(json.dumps(e, ensure_ascii=False) + "\n")
+    return out_file
+
+
+if __name__ == "__main__":
+    path = preprocess_logs()
+    print(f"saved {path}")

--- a/rl_train.py
+++ b/rl_train.py
@@ -1,0 +1,140 @@
+import csv
+import json
+import random
+from collections import deque
+from datetime import datetime
+from pathlib import Path
+from typing import List, Tuple
+
+import torch
+import torch.nn as nn
+import torch.optim as optim
+
+
+class DuelingDQN(nn.Module):
+    def __init__(self, state_dim: int, action_dim: int):
+        super().__init__()
+        self.feature = nn.Sequential(
+            nn.Linear(state_dim, 64),
+            nn.ReLU(),
+        )
+        self.adv = nn.Sequential(
+            nn.Linear(64, 32),
+            nn.ReLU(),
+            nn.Linear(32, action_dim),
+        )
+        self.val = nn.Sequential(
+            nn.Linear(64, 32),
+            nn.ReLU(),
+            nn.Linear(32, 1),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        feat = self.feature(x)
+        adv = self.adv(feat)
+        val = self.val(feat)
+        return val + adv - adv.mean(dim=1, keepdim=True)
+
+
+class DDQNAgent:
+    def __init__(self, state_dim: int = 5, action_dim: int = 3):
+        self.policy = DuelingDQN(state_dim, action_dim)
+        self.target = DuelingDQN(state_dim, action_dim)
+        self.target.load_state_dict(self.policy.state_dict())
+        self.memory: deque[Tuple] = deque(maxlen=10000)
+        self.optimizer = optim.Adam(self.policy.parameters(), lr=0.0005)
+        self.loss_fn = nn.HuberLoss()
+        self.steps = 0
+        self.eps_start = 1.0
+        self.eps_end = 0.05
+        self.eps_decay = 50000
+        self.action_dim = action_dim
+
+    def remember(self, *transition: Tuple):
+        self.memory.append(transition)
+
+    def act(self, state: torch.Tensor) -> int:
+        eps = max(self.eps_end, self.eps_start - self.steps / self.eps_decay)
+        if random.random() < eps:
+            return random.randrange(self.action_dim)
+        with torch.no_grad():
+            q = self.policy(state.unsqueeze(0))
+            return int(q.argmax().item())
+
+    def update(self, batch_size: int = 32, gamma: float = 0.99) -> float:
+        if len(self.memory) < batch_size:
+            return 0.0
+        batch = random.sample(self.memory, batch_size)
+        states, actions, rewards, next_states, dones = zip(*batch)
+        states = torch.tensor(states, dtype=torch.float32)
+        actions = torch.tensor(actions, dtype=torch.long).unsqueeze(1)
+        rewards = torch.tensor(rewards, dtype=torch.float32).unsqueeze(1)
+        next_states = torch.tensor(next_states, dtype=torch.float32)
+        dones = torch.tensor(dones, dtype=torch.float32).unsqueeze(1)
+
+        q_values = self.policy(states).gather(1, actions)
+        next_actions = self.policy(next_states).argmax(1, keepdim=True)
+        next_q = self.target(next_states).gather(1, next_actions)
+        target_q = rewards + gamma * next_q * (1 - dones)
+        loss = self.loss_fn(q_values, target_q.detach())
+        self.optimizer.zero_grad()
+        loss.backward()
+        self.optimizer.step()
+        self.steps += 1
+        if self.steps % 500 == 0:
+            self.target.load_state_dict(self.policy.state_dict())
+        return float(loss.item())
+
+
+def load_dataset(path: Path) -> List[Tuple]:
+    data = []
+    with open(path, encoding="utf-8") as f:
+        for line in f:
+            if not line.strip():
+                continue
+            d = json.loads(line)
+            if d["next_state"] is None:
+                continue
+            data.append(
+                (
+                    d["state"],
+                    d["action"],
+                    d["reward"],
+                    d["next_state"],
+                    d["done"],
+                )
+            )
+    return data
+
+
+def train(data_path: Path, out_dir: Path | None = None, episodes: int = 1):
+    out_dir = out_dir or Path(r"C:/Users/kanur/log/RL모델결과")
+    out_dir.mkdir(parents=True, exist_ok=True)
+    dataset = load_dataset(data_path)
+    agent = DDQNAgent()
+    rewards: List[float] = []
+    for ep in range(episodes):
+        random.shuffle(dataset)
+        total_loss = 0.0
+        for transition in dataset:
+            agent.remember(*transition)
+            loss = agent.update()
+            total_loss += loss
+        rewards.append(total_loss)
+    date_str = datetime.now().strftime("%Y-%m-%d")
+    weight_path = out_dir / "nova_policy_weights_v1.pth"
+    torch.save(agent.policy.state_dict(), weight_path)
+    csv_path = out_dir / f"reward_log_{date_str}.csv"
+    with open(csv_path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(["episode", "loss"])
+        for i, r in enumerate(rewards):
+            writer.writerow([i, r])
+    return weight_path, csv_path
+
+
+if __name__ == "__main__":
+    base = Path(r"C:/Users/kanur/log/강화학습전처리")
+    latest = sorted(base.glob("nova_rl_data_*.jsonl"))[-1]
+    w, c = train(latest)
+    print("saved", w, c)


### PR DESCRIPTION
## Summary
- preprocess judgment logs for RL datasets
- train a Dueling Double DQN from saved data
- require PyTorch for RL modules

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6843b4c8c60c8320b09b52ee9e1831c9