### PR TITLE
Fix indentation error in main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -257,8 +257,8 @@ class TradingApp:
         cumulative_return = stats.get("cumulative_return", 0.0)
 
         self.learning_agent.update()
-            bids = [[b["price"], b["volume"]] for b in order_book.get("bids", []) if b.get("volume")]
-            asks = [[a["price"], a["volume"]] for a in order_book.get("asks", []) if a.get("volume")]
+        bids = [[b["price"], b["volume"]] for b in order_book.get("bids", []) if b.get("volume")]
+        asks = [[a["price"], a["volume"]] for a in order_book.get("asks", []) if a.get("volume")]
 
         update_state(
             sentiment=sentiment,


### PR DESCRIPTION
## Summary
- clean up extraneous indentation in `main.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6843b945dab88320ba6ebfee4276a6df