### PR TITLE
Implement simplified NOVA judgement UI

### DIFF
--- a/static/nova_decision.css
+++ b/static/nova_decision.css
@@ -1,0 +1,27 @@
+body {
+    margin: 0;
+    font-family: "Pretendard", sans-serif;
+    background: linear-gradient(#0d1b2a, #1b263b);
+    color: #fff;
+}
+.wrapper {
+    max-width: 600px;
+    margin: 40px auto;
+    text-align: center;
+}
+.card {
+    background: rgba(0,0,0,0.3);
+    padding: 20px 30px;
+    border-radius: 8px;
+    box-shadow: 0 4px 10px rgba(0,0,0,0.4);
+}
+.section {
+    margin: 15px 0;
+}
+.quote {
+    margin-top: 30px;
+    font-style: italic;
+    color: #ccc;
+}
+.hold { color: #1b9c1b; }
+.sell { color: #e74c3c; }

--- a/static/nova_decision.js
+++ b/static/nova_decision.js
@@ -1,0 +1,34 @@
+async function fetchDecision() {
+    try {
+        const res = await fetch('/api/decision');
+        const data = await res.json();
+        updateUI(data);
+    } catch(e) {
+        console.error(e);
+    }
+}
+
+function updateUI(data) {
+    const emo = document.getElementById('marketEmotion');
+    emo.textContent = `${data.emotion} ${data.emotion_score ?? ''}`.trim();
+
+    const cmp = document.getElementById('humanVsNova');
+    cmp.textContent = `인간 예상: ${data.human_judgement} / NOVA: ${data.nova_judgement}`;
+
+    const score = document.getElementById('score');
+    score.textContent = `판단력: ${data.judgement_score ?? '-'}`;
+
+    const history = document.getElementById('history');
+    history.innerHTML = (data.history || []).map(h => `<div>${h}</div>`).join('') || '-';
+
+    const strategy = document.getElementById('strategy');
+    strategy.innerHTML = (data.strategy_updates || []).map(s => `<div>${s}</div>`).join('') || '-';
+
+    if(data.nova_judgement) {
+        score.classList.toggle('hold', data.nova_judgement === 'HOLD');
+        score.classList.toggle('sell', data.nova_judgement === 'SELL');
+    }
+}
+
+fetchDecision();
+setInterval(fetchDecision, 60000);

--- a/status_server.py
+++ b/status_server.py
@@ -139,7 +139,26 @@ def start_status_server(host: str = "0.0.0.0", port: int = 5000, *, position_man
 
     @app.route("/")
     def dashboard():
-        return render_template("status.html")
+        return render_template("nova_decision.html")
+
+    @app.route("/api/decision")
+    def api_decision():
+        decision_path = Path(r"C:/Users/kanur/log/판단/latest_decision.json")
+        news_path = Path(r"C:/Users/kanur/log/뉴스반영/latest_news.json")
+        data = {}
+        try:
+            if decision_path.exists():
+                with open(decision_path, "r", encoding="utf-8") as f:
+                    data = json.load(f)
+        except Exception:
+            data = {}
+        try:
+            if news_path.exists():
+                with open(news_path, "r", encoding="utf-8") as f:
+                    data["news"] = json.load(f)
+        except Exception:
+            pass
+        return jsonify(data)
 
     @app.route("/log")
     def log_view():

--- a/templates/nova_decision.html
+++ b/templates/nova_decision.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>NOVA 판단 시스템</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='nova_decision.css') }}">
+</head>
+<body>
+<div class="wrapper">
+    <h1>NOVA 판단 시스템</h1>
+    <p class="tagline">두려움 없이 직관에 귀 기울이다</p>
+    <div id="card" class="card">
+        <div class="section" id="marketEmotion">감정 로딩 중...</div>
+        <div class="section" id="humanVsNova">비교 로딩 중...</div>
+        <div class="section" id="score">판단력: -</div>
+        <div class="section" id="history">최근 판단 기록 로딩 중...</div>
+        <div class="section" id="strategy">전략 조정 내역 로딩 중...</div>
+        <div class="quote">“NOVA는 판단하지 않는다. 청하음을 기록한다.”</div>
+    </div>
+</div>
+<script src="{{ url_for('static', filename='nova_decision.js') }}"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add new simplified UI template `nova_decision.html`
- style NOVA judgement page with gradient background and centered card
- fetch decision and news data with `nova_decision.js`
- serve the new page from Flask server and provide `/api/decision`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843bc7eddc88320bed520aa19b3434a