### PR TITLE
Add live emotion decision UI

### DIFF
--- a/"b/C:/Users/kanur/log/\354\204\244\354\240\225/ui_config.json"
+++ b/"b/C:/Users/kanur/log/\354\204\244\354\240\225/ui_config.json"
@@ -1,0 +1,7 @@
+{
+  "watch_interval_seconds": 2,
+  "theme_mode": "emotion-reactive",
+  "max_log_items": 3,
+  "pulse_effect": true,
+  "font_family": "Pretendard"
+}

--- a/C:/Users/kanur/log/UI/2025-06-07_nova_decision_emotion_ui.html
+++ b/C:/Users/kanur/log/UI/2025-06-07_nova_decision_emotion_ui.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <title>NOVA 판단/감정 실시간 UI</title>
+  <style>
+    body {
+      margin:0;
+      font-family: "Pretendard", "Noto Sans KR", "Inter", sans-serif;
+      background: linear-gradient(#0d1b2a, #1b263b);
+      color:#fff;
+      height:100vh;
+      display:flex;
+      justify-content:center;
+      align-items:center;
+    }
+    .wrapper {
+      width:90%;
+      max-width:600px;
+    }
+    .card {
+      background:rgba(0,0,0,0.35);
+      padding:20px 30px;
+      border-radius:8px;
+      box-shadow:0 4px 10px rgba(0,0,0,0.4);
+    }
+    .section {
+      margin:15px 0;
+      color:#7dd3fc;
+    }
+    .fade-pulse {
+      animation: fadePulse 0.6s ease-in-out;
+    }
+    @keyframes fadePulse {
+      0% {opacity:0; box-shadow:0 0 0px #7dd3fc;}
+      50% {opacity:1; box-shadow:0 0 10px #7dd3fc;}
+      100% {box-shadow:0 0 0px transparent;}
+    }
+    .timeline div {margin-bottom:5px;}
+  </style>
+</head>
+<body>
+<div class="wrapper">
+  <div class="card" tabindex="0">
+    <div id="marketEmotion" class="section">-</div>
+    <div id="humanVsNova" class="section">-</div>
+    <div id="score" class="section">-</div>
+    <div id="history" class="section timeline">-</div>
+    <div id="strategy" class="section">-</div>
+  </div>
+</div>
+<script>
+const fs = require ? require('fs') : null;
+const path = require ? require('path') : null;
+const configPath = 'C:/Users/kanur/log/설정/ui_config.json';
+const decisionPath = 'C:/Users/kanur/log/판단/latest_decision.json';
+const newsPath = 'C:/Users/kanur/log/뉴스반영/latest_news.json';
+let watchInterval = 2000;
+let lastDecisionTime = 0;
+let lastNewsTime = 0;
+let historyItems = [];
+function loadConfig() {
+  if(!fs) return;
+  try {
+    const cfg = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    if(cfg.watch_interval_seconds) watchInterval = cfg.watch_interval_seconds * 1000;
+  } catch(e) {}
+}
+function readJson(p) {
+  try { return JSON.parse(fs.readFileSync(p, 'utf-8')); } catch(e) { return null; }
+}
+function updateUI(data) {
+  const emo = document.getElementById('marketEmotion');
+  const cmp = document.getElementById('humanVsNova');
+  const score = document.getElementById('score');
+  const hist = document.getElementById('history');
+  const strat = document.getElementById('strategy');
+  emo.textContent = data.emotion ? `${data.emotion} (${data.emotion_score ?? ''})`.trim() : '-';
+  cmp.textContent = data.human_judgement || data.nova_judgement ? `인간: ${data.human_judgement ?? '-'} / NOVA: ${data.nova_judgement ?? '-'}` : '-';
+  score.textContent = data.judgement_score !== undefined && data.judgement_score !== null ? `판단력: ${data.judgement_score}` : '-';
+  if(data.reason){ historyItems.unshift(`${data.time || ''} - ${data.reason}`); }
+  historyItems = historyItems.slice(0, (data.max_log_items || 3));
+  hist.innerHTML = historyItems.length ? historyItems.map(h=>`<div>${h}</div>`).join('') : '-';
+  strat.textContent = data.strategy_update || '-';
+  document.querySelector('.card').classList.add('fade-pulse');
+  setTimeout(()=>document.querySelector('.card').classList.remove('fade-pulse'),600);
+}
+function checkUpdates() {
+  if(!fs) return;
+  try {
+    const ds = fs.statSync(decisionPath).mtimeMs;
+    if(ds !== lastDecisionTime) {
+      lastDecisionTime = ds;
+      const data = readJson(decisionPath) || {};
+      const news = (fs.existsSync(newsPath)) ? readJson(newsPath) : {};
+      if(news && typeof news.emotion_shift !== 'undefined') {
+        const b = document.body.style;
+        b.background = `linear-gradient(${news.emotion_shift}, ${news.emotion_shift2 || '#1b263b'})`;
+      }
+      updateUI({...data, ...(news||{})});
+    }
+  } catch(e) {}
+}
+loadConfig();
+setInterval(checkUpdates, watchInterval);
+checkUpdates();
+</script>
+</body>
+</html>

--- a/C:/Users/kanur/log/UI/live_nova_decision_emotion_ui.html
+++ b/C:/Users/kanur/log/UI/live_nova_decision_emotion_ui.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <title>NOVA 판단/감정 실시간 UI</title>
+  <style>
+    body {
+      margin:0;
+      font-family: "Pretendard", "Noto Sans KR", "Inter", sans-serif;
+      background: linear-gradient(#0d1b2a, #1b263b);
+      color:#fff;
+      height:100vh;
+      display:flex;
+      justify-content:center;
+      align-items:center;
+    }
+    .wrapper {
+      width:90%;
+      max-width:600px;
+    }
+    .card {
+      background:rgba(0,0,0,0.35);
+      padding:20px 30px;
+      border-radius:8px;
+      box-shadow:0 4px 10px rgba(0,0,0,0.4);
+    }
+    .section {
+      margin:15px 0;
+      color:#7dd3fc;
+    }
+    .fade-pulse {
+      animation: fadePulse 0.6s ease-in-out;
+    }
+    @keyframes fadePulse {
+      0% {opacity:0; box-shadow:0 0 0px #7dd3fc;}
+      50% {opacity:1; box-shadow:0 0 10px #7dd3fc;}
+      100% {box-shadow:0 0 0px transparent;}
+    }
+    .timeline div {margin-bottom:5px;}
+  </style>
+</head>
+<body>
+<div class="wrapper">
+  <div class="card" tabindex="0">
+    <div id="marketEmotion" class="section">-</div>
+    <div id="humanVsNova" class="section">-</div>
+    <div id="score" class="section">-</div>
+    <div id="history" class="section timeline">-</div>
+    <div id="strategy" class="section">-</div>
+  </div>
+</div>
+<script>
+const fs = require ? require('fs') : null;
+const path = require ? require('path') : null;
+const configPath = 'C:/Users/kanur/log/설정/ui_config.json';
+const decisionPath = 'C:/Users/kanur/log/판단/latest_decision.json';
+const newsPath = 'C:/Users/kanur/log/뉴스반영/latest_news.json';
+let watchInterval = 2000;
+let lastDecisionTime = 0;
+let lastNewsTime = 0;
+let historyItems = [];
+function loadConfig() {
+  if(!fs) return;
+  try {
+    const cfg = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    if(cfg.watch_interval_seconds) watchInterval = cfg.watch_interval_seconds * 1000;
+  } catch(e) {}
+}
+function readJson(p) {
+  try { return JSON.parse(fs.readFileSync(p, 'utf-8')); } catch(e) { return null; }
+}
+function updateUI(data) {
+  const emo = document.getElementById('marketEmotion');
+  const cmp = document.getElementById('humanVsNova');
+  const score = document.getElementById('score');
+  const hist = document.getElementById('history');
+  const strat = document.getElementById('strategy');
+  emo.textContent = data.emotion ? `${data.emotion} (${data.emotion_score ?? ''})`.trim() : '-';
+  cmp.textContent = data.human_judgement || data.nova_judgement ? `인간: ${data.human_judgement ?? '-'} / NOVA: ${data.nova_judgement ?? '-'}` : '-';
+  score.textContent = data.judgement_score !== undefined && data.judgement_score !== null ? `판단력: ${data.judgement_score}` : '-';
+  if(data.reason){ historyItems.unshift(`${data.time || ''} - ${data.reason}`); }
+  historyItems = historyItems.slice(0, (data.max_log_items || 3));
+  hist.innerHTML = historyItems.length ? historyItems.map(h=>`<div>${h}</div>`).join('') : '-';
+  strat.textContent = data.strategy_update || '-';
+  document.querySelector('.card').classList.add('fade-pulse');
+  setTimeout(()=>document.querySelector('.card').classList.remove('fade-pulse'),600);
+}
+function checkUpdates() {
+  if(!fs) return;
+  try {
+    const ds = fs.statSync(decisionPath).mtimeMs;
+    if(ds !== lastDecisionTime) {
+      lastDecisionTime = ds;
+      const data = readJson(decisionPath) || {};
+      const news = (fs.existsSync(newsPath)) ? readJson(newsPath) : {};
+      if(news && typeof news.emotion_shift !== 'undefined') {
+        const b = document.body.style;
+        b.background = `linear-gradient(${news.emotion_shift}, ${news.emotion_shift2 || '#1b263b'})`;
+      }
+      updateUI({...data, ...(news||{})});
+    }
+  } catch(e) {}
+}
+loadConfig();
+setInterval(checkUpdates, watchInterval);
+checkUpdates();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create new emotion-reactive NOVA decision layout
- include configurable file watchers for decision and news JSON
- add default UI config

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843c30e4c0c832085df38c96f6e2907