### PR TITLE
Implement decision API and UI fetch

### DIFF
--- a/C:/Users/kanur/log/UI/live_nova_decision_emotion_ui.html
+++ b/C:/Users/kanur/log/UI/live_nova_decision_emotion_ui.html
@@ -42,68 +42,30 @@
 <body>
 <div class="wrapper">
   <div class="card" tabindex="0">
-    <div id="marketEmotion" class="section">-</div>
-    <div id="humanVsNova" class="section">-</div>
+    <div id="market-emotion" class="section">-</div>
+    <div id="action" class="section">-</div>
+    <div id="reason" class="section">-</div>
     <div id="score" class="section">-</div>
-    <div id="history" class="section timeline">-</div>
-    <div id="strategy" class="section">-</div>
+    <div id="log" class="section timeline">-</div>
   </div>
 </div>
 <script>
-const fs = require ? require('fs') : null;
-const path = require ? require('path') : null;
-const configPath = 'C:/Users/kanur/log/설정/ui_config.json';
-const decisionPath = 'C:/Users/kanur/log/판단/latest_decision.json';
-const newsPath = 'C:/Users/kanur/log/뉴스반영/latest_news.json';
-let watchInterval = 2000;
-let lastDecisionTime = 0;
-let lastNewsTime = 0;
-let historyItems = [];
-function loadConfig() {
-  if(!fs) return;
-  try {
-    const cfg = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-    if(cfg.watch_interval_seconds) watchInterval = cfg.watch_interval_seconds * 1000;
-  } catch(e) {}
+function fetchDecision() {
+  fetch('/api/decision')
+    .then(res => res.json())
+    .then(data => {
+      document.getElementById('market-emotion').textContent = data.classified_emotion ?? '-';
+      document.getElementById('action').textContent = data.action ?? '-';
+      document.getElementById('reason').textContent = data.reason ?? '-';
+      document.getElementById('score').textContent = data.score_vs_human ?? '-';
+      document.getElementById('log').textContent = `${data.time ?? ''} | ${data.action ?? ''} | ${data.reason ?? ''}`;
+      document.querySelector('.card').classList.add('fade-pulse');
+      setTimeout(()=>document.querySelector('.card').classList.remove('fade-pulse'),600);
+    })
+    .catch(err => console.error('NOVA 판단 정보 수신 실패:', err));
 }
-function readJson(p) {
-  try { return JSON.parse(fs.readFileSync(p, 'utf-8')); } catch(e) { return null; }
-}
-function updateUI(data) {
-  const emo = document.getElementById('marketEmotion');
-  const cmp = document.getElementById('humanVsNova');
-  const score = document.getElementById('score');
-  const hist = document.getElementById('history');
-  const strat = document.getElementById('strategy');
-  emo.textContent = data.emotion ? `${data.emotion} (${data.emotion_score ?? ''})`.trim() : '-';
-  cmp.textContent = data.human_judgement || data.nova_judgement ? `인간: ${data.human_judgement ?? '-'} / NOVA: ${data.nova_judgement ?? '-'}` : '-';
-  score.textContent = data.judgement_score !== undefined && data.judgement_score !== null ? `판단력: ${data.judgement_score}` : '-';
-  if(data.reason){ historyItems.unshift(`${data.time || ''} - ${data.reason}`); }
-  historyItems = historyItems.slice(0, (data.max_log_items || 3));
-  hist.innerHTML = historyItems.length ? historyItems.map(h=>`<div>${h}</div>`).join('') : '-';
-  strat.textContent = data.strategy_update || '-';
-  document.querySelector('.card').classList.add('fade-pulse');
-  setTimeout(()=>document.querySelector('.card').classList.remove('fade-pulse'),600);
-}
-function checkUpdates() {
-  if(!fs) return;
-  try {
-    const ds = fs.statSync(decisionPath).mtimeMs;
-    if(ds !== lastDecisionTime) {
-      lastDecisionTime = ds;
-      const data = readJson(decisionPath) || {};
-      const news = (fs.existsSync(newsPath)) ? readJson(newsPath) : {};
-      if(news && typeof news.emotion_shift !== 'undefined') {
-        const b = document.body.style;
-        b.background = `linear-gradient(${news.emotion_shift}, ${news.emotion_shift2 || '#1b263b'})`;
-      }
-      updateUI({...data, ...(news||{})});
-    }
-  } catch(e) {}
-}
-loadConfig();
-setInterval(checkUpdates, watchInterval);
-checkUpdates();
+fetchDecision();
+setInterval(fetchDecision, 2000);
 </script>
 </body>
 </html>

--- a/main.py
+++ b/main.py
@@ -23,6 +23,8 @@ from agents.missed_hold_tracker import track_failed_hold
 from agents.human_compare import HumanCompareAgent
 from agents.utils import get_upbit_candles, get_upbit_orderbook
 from status_server import start_status_server, update_state
+import json
+from pathlib import Path
 from log_analyzer import load_logs, analyze_logs
 from version import STRATEGY_VERSION
 
@@ -145,6 +147,24 @@ class TradingApp:
             strategy_version=STRATEGY_VERSION,
             conflict_analysis=self.entry_agent.last_conflict,
         )
+
+        decision_data = {
+            "time": datetime.now().strftime("%Y-%m-%d %H:%M"),
+            "action": signal,
+            "reason": reason,
+            "human_likely_action": human_action,
+            "score_vs_human": score_vs_human,
+            "classified_emotion": classified_emotion,
+            "market_emotion_index": emotion_index,
+        }
+        update_state(decision=decision_data)
+        try:
+            p = Path(r"C:/Users/kanur/log/판단/latest_decision.json")
+            p.parent.mkdir(parents=True, exist_ok=True)
+            with open(p, "w", encoding="utf-8") as f:
+                json.dump(decision_data, f, ensure_ascii=False)
+        except Exception:
+            pass
 
         allow_entry, entry_reason = self.entry_agent.decide_entry(signal, reason, score_percent)
 

--- a/status_server.py
+++ b/status_server.py
@@ -64,6 +64,7 @@ state_store = {
     "buy_count": 0,
     "sell_count": 0,
     "theme": load_ui_config().get("theme", "Dark Insight"),
+    "decision": {},
 }
 
 
@@ -143,21 +144,15 @@ def start_status_server(host: str = "0.0.0.0", port: int = 5000, *, position_man
 
     @app.route("/api/decision")
     def api_decision():
-        decision_path = Path(r"C:/Users/kanur/log/판단/latest_decision.json")
-        news_path = Path(r"C:/Users/kanur/log/뉴스반영/latest_news.json")
-        data = {}
-        try:
-            if decision_path.exists():
-                with open(decision_path, "r", encoding="utf-8") as f:
-                    data = json.load(f)
-        except Exception:
-            data = {}
-        try:
-            if news_path.exists():
-                with open(news_path, "r", encoding="utf-8") as f:
-                    data["news"] = json.load(f)
-        except Exception:
-            pass
+        data = state_store.get("decision", {})
+        if not data:
+            decision_path = Path(r"C:/Users/kanur/log/판단/latest_decision.json")
+            try:
+                if decision_path.exists():
+                    with open(decision_path, "r", encoding="utf-8") as f:
+                        data = json.load(f)
+            except Exception:
+                data = {}
         return jsonify(data)
 
     @app.route("/log")


### PR DESCRIPTION
## Summary
- expose latest decision via `state_store` and JSON file
- fetch decision info in `live_nova_decision_emotion_ui.html`
- store decision data from main loop for API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843cd31f1fc8320966fcf55c9497ffb