### PR TITLE
Remove stray gitignore line

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,4 +39,3 @@ Thumbs.db
 __pycache__/
 *.pyc
 data/
-C:


### PR DESCRIPTION
## Summary
- remove erroneous `C:` from `.gitignore`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6844e305b5208320bfac40b00059216b