### PR TITLE
Add configurable log directory

### DIFF
--- a/log_archiver.py
+++ b/log_archiver.py
@@ -2,9 +2,10 @@ import os
 import zipfile
 from datetime import datetime
 from pathlib import Path
+from config import LOG_BASE_DIR
 
 
-def archive_logs(base_dir: str = r"C:/Users/kanur/log", *, days: int = 1) -> None:
+def archive_logs(base_dir: str | Path = LOG_BASE_DIR, *, days: int = 1) -> None:
     """Compress log files older than ``days`` into per-day zip archives.
 
     Parameters

--- a/rl_preprocess.py
+++ b/rl_preprocess.py
@@ -2,9 +2,10 @@ import json
 from pathlib import Path
 from datetime import datetime
 from typing import List, Dict, Any
+from config import LOG_BASE_DIR
 
 
-def preprocess_logs(base_dir: str = r"C:/Users/kanur/log") -> Path:
+def preprocess_logs(base_dir: str | Path = LOG_BASE_DIR) -> Path:
     """Convert judgment logs into RL format and save to a jsonl file.
 
     The output file will be named ``nova_rl_data_{YYYY-MM-DD}.jsonl`` under

--- a/rl_train.py
+++ b/rl_train.py
@@ -5,6 +5,7 @@ from collections import deque
 from datetime import datetime
 from pathlib import Path
 from typing import List, Tuple
+from config import LOG_BASE_DIR
 
 import torch
 import torch.nn as nn
@@ -108,7 +109,7 @@ def load_dataset(path: Path) -> List[Tuple]:
 
 
 def train(data_path: Path, out_dir: Path | None = None, episodes: int = 1):
-    out_dir = out_dir or Path(r"C:/Users/kanur/log/RL모델결과")
+    out_dir = out_dir or (LOG_BASE_DIR / "RL모델결과")
     out_dir.mkdir(parents=True, exist_ok=True)
     dataset = load_dataset(data_path)
     agent = DDQNAgent()
@@ -134,7 +135,7 @@ def train(data_path: Path, out_dir: Path | None = None, episodes: int = 1):
 
 
 if __name__ == "__main__":
-    base = Path(r"C:/Users/kanur/log/강화학습전처리")
+    base = LOG_BASE_DIR / "강화학습전처리"
     latest = sorted(base.glob("nova_rl_data_*.jsonl"))[-1]
     w, c = train(latest)
     print("saved", w, c)

--- a/src/agents/daily_logger.py
+++ b/src/agents/daily_logger.py
@@ -2,13 +2,14 @@ import json
 import os
 from datetime import datetime
 from pathlib import Path
+from config import LOG_BASE_DIR
 
 
 class DailyLogger:
     """Simple logger that appends success and failure events by day."""
 
     def __init__(self, base_dir: str | os.PathLike | None = None):
-        base = Path(base_dir) if base_dir is not None else Path(r"C:/Users/kanur/log")
+        base = Path(base_dir) if base_dir is not None else LOG_BASE_DIR
         self.log_dir = base / "NOVA_LOGS"
         self.log_dir.mkdir(parents=True, exist_ok=True)
 

--- a/src/agents/logger_agent.py
+++ b/src/agents/logger_agent.py
@@ -3,8 +3,9 @@ import threading
 from pathlib import Path
 from datetime import datetime
 from .news_adjuster import news_adjuster
+from config import LOG_BASE_DIR
 
-LOG_DIR = Path(r"C:/Users/kanur/log")
+LOG_DIR = LOG_BASE_DIR
 _lock = threading.Lock()
 
 

--- a/src/agents/missed_hold_tracker.py
+++ b/src/agents/missed_hold_tracker.py
@@ -3,13 +3,14 @@ import json
 from datetime import datetime
 from pathlib import Path
 from typing import Callable
+from config import LOG_BASE_DIR
 
 
 ANALYSIS_DELAY_SEC = 5 * 60  # 5 minutes
 THRESHOLD_PCT = 1.0
 MIN_CONFIDENCE = 50.0
 
-LOG_DIR = Path(r"C:/Users/kanur/log/missed_hold")
+LOG_DIR = LOG_BASE_DIR / "missed_hold"
 LOG_FILE = LOG_DIR / "failed_holds.jsonl"
 
 

--- a/src/agents/session_logger.py
+++ b/src/agents/session_logger.py
@@ -1,13 +1,14 @@
 import json
 from datetime import datetime
 from pathlib import Path
+from config import LOG_BASE_DIR
 
 
 class SessionLogger:
     """Unified logger that appends entries to a single file per session."""
 
     def __init__(self, base_dir: str | Path | None = None):
-        base = Path(base_dir) if base_dir is not None else Path(r"C:/Users/kanur/log")
+        base = Path(base_dir) if base_dir is not None else LOG_BASE_DIR
         self.log_dir = base / "NOVA_LOGS"
         self.log_dir.mkdir(parents=True, exist_ok=True)
         session_id = datetime.now().strftime("%Y%m%d_%H%M%S")

--- a/src/config.py
+++ b/src/config.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+import os
+from pathlib import Path
+
+LOG_BASE_DIR = Path(os.environ.get('NOVA_LOG_DIR', Path.home() / 'nova_logs'))

--- a/status_server.py
+++ b/status_server.py
@@ -3,8 +3,9 @@ import threading
 from datetime import datetime, timedelta
 from pathlib import Path
 import json
+from config import LOG_BASE_DIR
 
-CONFIG_PATH = Path(r"C:/Users/kanur/log/설정/ui_config.json")
+CONFIG_PATH = LOG_BASE_DIR / "설정" / "ui_config.json"
 
 
 def load_ui_config():
@@ -146,7 +147,7 @@ def start_status_server(host: str = "0.0.0.0", port: int = 5000, *, position_man
     def api_decision():
         data = state_store.get("decision", {})
         if not data:
-            decision_path = Path(r"C:/Users/kanur/log/판단/latest_decision.json")
+            decision_path = LOG_BASE_DIR / "판단" / "latest_decision.json"
             try:
                 if decision_path.exists():
                     with open(decision_path, "r", encoding="utf-8") as f:

--- a/tests/test_daily_logger.py
+++ b/tests/test_daily_logger.py
@@ -8,6 +8,7 @@ from agents.daily_logger import DailyLogger
 
 
 def test_daily_logger_write(tmp_path):
+    os.environ['NOVA_LOG_DIR'] = str(tmp_path)
     logger = DailyLogger(base_dir=tmp_path)
     logger.log_failure('AgentA', 'reason')
     logger.log_success('AgentB', 'BUY', price=1.23, strategy='s', return_rate=0.1)

--- a/tests/test_logger_judgment.py
+++ b/tests/test_logger_judgment.py
@@ -9,6 +9,7 @@ from agents.logger_agent import LoggerAgent
 
 
 def test_log_judgment(tmp_path):
+    os.environ['NOVA_LOG_DIR'] = str(tmp_path)
     logger = LoggerAgent(log_dir=tmp_path)
     logger.log_judgment(
         action='BUY',

--- a/tests/test_session_logger.py
+++ b/tests/test_session_logger.py
@@ -7,6 +7,7 @@ from agents.session_logger import SessionLogger
 
 
 def test_session_logger(tmp_path):
+    os.environ['NOVA_LOG_DIR'] = str(tmp_path)
     logger = SessionLogger(base_dir=tmp_path)
     logger.log_success('A', 'BUY', price=1.0, strategy='s', return_rate=0.1)
     logger.log_failure('B', 'error')


### PR DESCRIPTION
## Summary
- centralize log base directory in `src/config.py`
- use `LOG_BASE_DIR` across agents and utilities
- update status server and RL scripts to use new location
- allow tests to override `NOVA_LOG_DIR`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844e3ae8bfc8320ab95f37c18e16ffc