### PR TITLE
Use LOG_BASE_DIR in status server

### DIFF
--- a/status_server.py
+++ b/status_server.py
@@ -158,7 +158,7 @@ def start_status_server(host: str = "0.0.0.0", port: int = 5000, *, position_man
 
     @app.route("/log")
     def log_view():
-        logs = load_logs("log")
+        logs = load_logs(str(LOG_BASE_DIR))
         stats = analyze_logs(logs)
         recent = []
         for l in get_recent_logs(logs, 10):


### PR DESCRIPTION
## Summary
- refer to LOG_BASE_DIR constant for log viewer in status server

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844e5b148588320ac8a82f9979b5608