### PR TITLE
Refactor log path configuration

### DIFF
--- a/src/agents/market_sentiment.py
+++ b/src/agents/market_sentiment.py
@@ -1,6 +1,7 @@
 import json
 import math
 from pathlib import Path
+from config import LOG_BASE_DIR
 from datetime import datetime
 from typing import List, Optional
 
@@ -151,7 +152,7 @@ class MarketSentimentAgent:
     # --------------------------------------------------------------
     def _update_ma(self) -> None:
         """Update 3-day moving average of emotion index."""
-        path = Path(r"C:\Users\kanur\log\감정지수\emotion_MA.json")
+        path = LOG_BASE_DIR / "감정지수" / "emotion_MA.json"
         path.parent.mkdir(parents=True, exist_ok=True)
         try:
             with open(path, "r", encoding="utf-8") as f:

--- a/src/agents/strategy_scorer.py
+++ b/src/agents/strategy_scorer.py
@@ -1,6 +1,7 @@
 import json
 from datetime import datetime
 from pathlib import Path
+from config import LOG_BASE_DIR
 from typing import Dict, Iterable
 
 DEFAULT_WEIGHTS: Dict[str, float] = {
@@ -25,7 +26,7 @@ class StrategyScorer:
         self.weights: Dict[str, float] = dict(DEFAULT_WEIGHTS)
         if weights:
             self.weights.update(weights)
-        base = Path(log_dir) if log_dir is not None else Path(r"C:/Users/kanur/log/strategy_scorer")
+        base = Path(log_dir) if log_dir is not None else LOG_BASE_DIR / "strategy_scorer"
         base.mkdir(parents=True, exist_ok=True)
         self.log_dir = base
         self.history_path = base / history_file

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+import os
+import pytest
+
+@pytest.fixture(autouse=True)
+def _set_nova_log_dir(tmp_path, monkeypatch):
+    monkeypatch.setenv('NOVA_LOG_DIR', str(tmp_path))
+    yield
+


### PR DESCRIPTION
## Summary
- centralize log directory logic in `config.py`
- update `StrategyScorer` and `MarketSentimentAgent` to use `LOG_BASE_DIR`
- ensure tests isolate logs by setting `NOVA_LOG_DIR`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844e936b2e08320a34b9c0c91845cf0