### PR TITLE
Restore config and link UI with ngrok

### DIFF
--- a/UI/live_nova_decision_emotion_ui.html
+++ b/UI/live_nova_decision_emotion_ui.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>NOVA Decision Viewer</title>
+  <style>
+    body { font-family: sans-serif; margin: 2rem; }
+    pre { background: #f0f0f0; padding: 1rem; }
+  </style>
+</head>
+<body>
+  <h1>NOVA Decision Viewer</h1>
+  <pre id="status">Loading...</pre>
+  <script>
+    async function load() {
+      try {
+        const res = await fetch('/api/status');
+        const data = await res.json();
+        document.getElementById('status').textContent = JSON.stringify(data, null, 2);
+      } catch (err) {
+        document.getElementById('status').textContent = 'Error fetching data';
+      }
+    }
+    load();
+    setInterval(load, 1000);
+  </script>
+</body>
+</html>

--- a/config.py
+++ b/config.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+import os
+
+# Log directory
+LOG_BASE_DIR = Path(os.environ.get("NOVA_LOG_DIR", r"C:/Users/kanur/log"))
+
+# Optional HTML UI file path
+UI_PATH = LOG_BASE_DIR / "UI" / "live_nova_decision_emotion_ui.html"
+
+# ngrok settings
+USE_NGROK = os.environ.get("USE_NGROK", "True") == "True"
+NGROK_PORT = int(os.environ.get("NGROK_PORT", "5000"))
+
+# Local status server port
+LOCAL_SERVER_PORT = int(os.environ.get("LOCAL_SERVER_PORT", "5000"))

--- a/run_with_ngrok.py
+++ b/run_with_ngrok.py
@@ -1,6 +1,7 @@
 import sys
 import subprocess
 import time
+import webbrowser
 
 try:
     from pyngrok import ngrok
@@ -10,16 +11,28 @@ except ImportError:  # pragma: no cover - auto install for convenience
 
 from status_server import start_status_server, update_state
 from main import TradingApp, SYMBOL
+from config import USE_NGROK, NGROK_PORT, LOCAL_SERVER_PORT
 from agents.utils import get_upbit_orderbook
 
 
 def main():
     app = TradingApp()
     start_status_server(
-        position_manager=app.position_manager, logger_agent=app.logger
+        port=LOCAL_SERVER_PORT,
+        position_manager=app.position_manager,
+        logger_agent=app.logger,
     )
-    public_url = ngrok.connect(5000)
-    print(f"\N{link symbol} 외부 접속 주소: {public_url}")
+
+    url = f"http://localhost:{LOCAL_SERVER_PORT}"
+    if USE_NGROK:
+        public_url = ngrok.connect(NGROK_PORT)
+        print(f"\N{link symbol} 외부 접속 주소: {public_url}")
+        url = str(public_url)
+
+    try:
+        webbrowser.open(url)
+    except Exception:
+        pass
 
     symbol = SYMBOL
     while True:

--- a/status_server.py
+++ b/status_server.py
@@ -3,7 +3,7 @@ import threading
 from datetime import datetime, timedelta
 from pathlib import Path
 import json
-from config import LOG_BASE_DIR
+from config import LOG_BASE_DIR, UI_PATH, LOCAL_SERVER_PORT
 
 CONFIG_PATH = LOG_BASE_DIR / "설정" / "ui_config.json"
 
@@ -110,7 +110,7 @@ def update_state(**kwargs):
     state_store["equity"] = equity
 
 
-def start_status_server(host: str = "0.0.0.0", port: int = 5000, *, position_manager=None, logger_agent=None):
+def start_status_server(host: str = "0.0.0.0", port: int = LOCAL_SERVER_PORT, *, position_manager=None, logger_agent=None):
     """Start a background Flask server exposing current trading status."""
 
     app = Flask(
@@ -200,5 +200,13 @@ def start_status_server(host: str = "0.0.0.0", port: int = 5000, *, position_man
         daemon=True,
     )
     thread.start()
+
+    # Automatically open the legacy UI if available
+    try:
+        if UI_PATH.exists():
+            import webbrowser
+            webbrowser.open(UI_PATH.as_uri())
+    except Exception:
+        pass
     return thread
 


### PR DESCRIPTION
## Summary
- restore missing `config.py` with log and ngrok settings
- serve a simple HTML dashboard and open it when the server starts
- expose server via ngrok in `run_with_ngrok.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847ee86bf48832084977d1060c60a20