### PR TITLE
Add auto UI launch and refresh

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ requests>=2.0
 matplotlib>=3.5
 pyngrok>=7.0
 torch
+psutil>=5.9

--- a/ui-react/dist/index.html
+++ b/ui-react/dist/index.html
@@ -10,5 +10,20 @@
   </head>
   <body>
     <div id="root"></div>
+    <script>
+      let lastTs = null;
+      async function pollDecision() {
+        try {
+          const res = await fetch('/api/decision');
+          const data = await res.json();
+          const ts = data.timestamp || data.time;
+          if (lastTs && ts && ts !== lastTs) {
+            location.reload();
+          }
+          lastTs = ts;
+        } catch (e) {}
+      }
+      setInterval(pollDecision, 2000);
+    </script>
   </body>
 </html>

--- a/ui-react/index.html
+++ b/ui-react/index.html
@@ -9,5 +9,20 @@
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
+    <script>
+      let lastTs = null;
+      async function pollDecision() {
+        try {
+          const res = await fetch('/api/decision');
+          const data = await res.json();
+          const ts = data.timestamp || data.time;
+          if (lastTs && ts && ts !== lastTs) {
+            location.reload();
+          }
+          lastTs = ts;
+        } catch (e) {}
+      }
+      setInterval(pollDecision, 2000);
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- launch React UI from `main.py` only once using `psutil`
- refresh UI when decisions update by polling `/api/decision`
- add `psutil` dependency

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*


------
https://chatgpt.com/codex/tasks/task_e_6848b724f1288320bf92ee54d35e3445