### PR TITLE
Add VisualizerAgent and config updates

### DIFF
--- a/log_analyzer.py
+++ b/log_analyzer.py
@@ -5,9 +5,13 @@ from collections import defaultdict
 from pathlib import Path
 from typing import List, Dict, Tuple
 from datetime import datetime
-import matplotlib.pyplot as plt
 import io
 import base64
+
+try:
+    import matplotlib.pyplot as plt  # type: ignore
+except Exception:  # pragma: no cover - simplify test environment
+    plt = None
 
 
 def load_logs(log_dir: str = "log") -> List[dict]:
@@ -133,7 +137,7 @@ def get_recent_logs(logs: List[dict], n: int = 10) -> List[dict]:
 
 def generate_bar_chart(data: Dict[str, float]) -> str:
     """Return a base64 PNG bar chart for the given mapping."""
-    if not data:
+    if plt is None or not data:
         return ""
     fig, ax = plt.subplots(figsize=(4, 3))
     ax.bar(list(data.keys()), list(data.values()))
@@ -148,7 +152,7 @@ def generate_bar_chart(data: Dict[str, float]) -> str:
 
 def generate_line_chart(curve: List[Tuple[str, float]]) -> str:
     """Return a base64 PNG line chart from cumulative return curve."""
-    if not curve:
+    if plt is None or not curve:
         return ""
     x = list(range(len(curve)))
     y = [c[1] for c in curve]

--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -14,6 +14,7 @@ from .missed_hold_tracker import track_failed_hold
 from .strategy_scorer import StrategyScorer
 from .human_compare import HumanCompareAgent
 from .news_adjuster import NewsAdjuster, news_adjuster
+from .visualizer_agent import VisualizerAgent
 
 __all__ = [
     'MarketSentimentAgent',
@@ -33,4 +34,5 @@ __all__ = [
     'HumanCompareAgent',
     'NewsAdjuster',
     'news_adjuster',
+    'VisualizerAgent',
 ]

--- a/src/agents/utils.py
+++ b/src/agents/utils.py
@@ -1,4 +1,17 @@
-import requests
+"""Utility functions for fetching market data."""
+
+try:
+    import requests  # type: ignore
+except Exception:  # pragma: no cover - fallback for minimal environments
+    class _DummyRequests:
+        class RequestException(Exception):
+            pass
+
+        @staticmethod
+        def get(*_, **__):
+            raise _DummyRequests.RequestException("requests library not available")
+
+    requests = _DummyRequests()
 import time
 from typing import List, Dict, Any
 

--- a/src/agents/visualizer_agent.py
+++ b/src/agents/visualizer_agent.py
@@ -1,0 +1,12 @@
+class VisualizerAgent:
+    """Simple wrapper that forwards state updates to ``status_server``."""
+
+    def __init__(self, update_func=None):
+        if update_func is None:
+            from status_server import update_state
+            update_func = update_state
+        self.update_func = update_func
+
+    def update(self, **state):
+        """Forward provided state dictionary to the status server."""
+        self.update_func(**state)

--- a/src/config.py
+++ b/src/config.py
@@ -2,4 +2,16 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
-LOG_BASE_DIR = Path(os.environ.get('NOVA_LOG_DIR', Path.home() / 'nova_logs'))
+# Base directory for all log files.  The location can be overridden by setting
+# the ``NOVA_LOG_DIR`` environment variable.  When not provided, it defaults to
+# ``C:/Users/kanur/log`` to match the behaviour of ``config.py`` in the project
+# root.  Using ``Path`` ensures compatibility across platforms.
+LOG_BASE_DIR = Path(os.environ.get("NOVA_LOG_DIR", r"C:/Users/kanur/log"))
+
+# Optional path to the legacy HTML UI.  This file is opened automatically by the
+# status server if present.
+UI_PATH = LOG_BASE_DIR / "UI" / "live_nova_decision_emotion_ui.html"
+
+# Port used by the local Flask status server.  The value may be overridden via
+# the ``LOCAL_SERVER_PORT`` environment variable.
+LOCAL_SERVER_PORT = int(os.environ.get("LOCAL_SERVER_PORT", "5000"))


### PR DESCRIPTION
## Summary
- default log directory now uses the same path as the root config
- support missing dependencies for requests and matplotlib
- simple VisualizerAgent for forwarding UI state

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848bc073f7c83209021cb1f15464581