### PR TITLE
Add helper scripts for legacy UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ npm run build      # outputs files to ui-react/dist
 Open `ui-react/dist/index.html` in your browser to view the dashboard.
 The Python utilities in this repository operate independently of the UI.
 
+## Legacy HTML UI
+
+The script `nova_ui_update.py` writes a small `ui_data.json` file every few
+seconds using live data from Upbit. When the legacy HTML file defined by
+`config.UI_PATH` exists, running this script automatically opens it in your
+browser and keeps the data refreshed.
+
 ## Disclaimer / 면책 조항
 
 **English:** This project is provided for demonstration and educational purposes only. It is not intended as financial advice or a solicitation to trade. Using this code for real trading is done at your own risk, and the authors disclaim all liability for any potential losses.

--- a/nova_core.py
+++ b/nova_core.py
@@ -1,0 +1,25 @@
+import json
+from pathlib import Path
+from config import LOG_BASE_DIR
+
+
+DECISION_PATH = LOG_BASE_DIR / "판단" / "latest_decision.json"
+NEWS_PATH = LOG_BASE_DIR / "뉴스반영" / "latest_news.json"
+
+
+def get_latest_decision() -> dict:
+    """Return the latest decision data if available."""
+    try:
+        with open(DECISION_PATH, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except Exception:
+        return {}
+
+
+def get_latest_news() -> dict:
+    """Return the latest news sentiment data if available."""
+    try:
+        with open(NEWS_PATH, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except Exception:
+        return {}

--- a/nova_ui_update.py
+++ b/nova_ui_update.py
@@ -1,0 +1,58 @@
+"""Background updater for the legacy NOVA HTML UI."""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+import webbrowser
+from pathlib import Path
+
+from upbit_api import get_orderbook, get_current_price
+from nova_core import get_latest_decision, get_latest_news
+from config import LOG_BASE_DIR, UI_PATH
+
+
+UI_DATA_PATH = LOG_BASE_DIR / "UI" / "ui_data.json"
+
+
+def update_ui(symbol: str = "KRW-BTC") -> None:
+    prev_hash: str | None = None
+    while True:
+        try:
+            orderbook = get_orderbook(symbol)
+            price_info = get_current_price(symbol)
+            decision = get_latest_decision()
+            news = get_latest_news()
+
+            ui_data = {
+                "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
+                "price": price_info.get("trade_price"),
+                "change_rate": price_info.get("signed_change_rate"),
+                "orderbook": orderbook,
+                "action": decision.get("action"),
+                "reason": decision.get("reason"),
+                "source_news": decision.get("source_news", []),
+                "score_vs_human": decision.get("score_vs_human"),
+                "news": news,
+            }
+
+            UI_DATA_PATH.parent.mkdir(parents=True, exist_ok=True)
+            with open(UI_DATA_PATH, "w", encoding="utf-8") as f:
+                json.dump(ui_data, f, ensure_ascii=False, indent=2)
+        except Exception as exc:  # pragma: no cover - runtime errors only
+            print("UI update error:", exc)
+
+        time.sleep(2)
+
+
+def launch_ui() -> None:
+    if Path(UI_PATH).exists():
+        webbrowser.open(Path(UI_PATH).as_uri())
+    else:
+        print("UI HTML 파일이 존재하지 않습니다.")
+
+
+if __name__ == "__main__":
+    threading.Thread(target=update_ui, daemon=True).start()
+    launch_ui()

--- a/upbit_api.py
+++ b/upbit_api.py
@@ -1,0 +1,28 @@
+import requests
+from typing import Dict, Any
+
+
+def get_orderbook(market: str = "KRW-BTC", depth: int = 5) -> Dict[str, Any]:
+    """Return simplified orderbook snapshot from Upbit."""
+    url = "https://api.upbit.com/v1/orderbook"
+    params = {"markets": market}
+    response = requests.get(url, params=params, timeout=5)
+    response.raise_for_status()
+    data = response.json()[0]
+    units = data.get("orderbook_units", [])[:depth]
+    bids = [{"price": u["bid_price"], "volume": u["bid_size"]} for u in units]
+    asks = [{"price": u["ask_price"], "volume": u["ask_size"]} for u in units]
+    return {"bids": bids, "asks": asks, "bid_volume": data.get("total_bid_size"), "ask_volume": data.get("total_ask_size")}
+
+
+def get_current_price(market: str = "KRW-BTC") -> Dict[str, Any]:
+    """Return current trade price and change rate."""
+    url = "https://api.upbit.com/v1/ticker"
+    params = {"markets": market}
+    response = requests.get(url, params=params, timeout=5)
+    response.raise_for_status()
+    data = response.json()[0]
+    return {
+        "trade_price": data.get("trade_price"),
+        "signed_change_rate": data.get("signed_change_rate"),
+    }


### PR DESCRIPTION
## Summary
- implement `upbit_api` with Upbit REST helpers
- provide `nova_core` utilities for reading recent decision/news data
- add `nova_ui_update.py` for refreshing the legacy HTML dashboard
- document legacy HTML workflow in `README`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848ce9aa46c83208b1f35d77583c2c5