### PR TITLE
Implement decision persistence helper and UI launch

### DIFF
--- a/config.py
+++ b/config.py
@@ -7,6 +7,9 @@ LOG_BASE_DIR = Path(os.environ.get("NOVA_LOG_DIR", r"C:/Users/kanur/log"))
 # Optional HTML UI file path
 UI_PATH = LOG_BASE_DIR / "UI" / "live_nova_decision_emotion_ui.html"
 
+# JSON file storing the most recent trading decision
+DECISION_PATH = LOG_BASE_DIR / "판단" / "latest_decision.json"
+
 # ngrok settings
 USE_NGROK = os.environ.get("USE_NGROK", "True") == "True"
 NGROK_PORT = int(os.environ.get("NGROK_PORT", "5000"))

--- a/nova_core.py
+++ b/nova_core.py
@@ -1,9 +1,8 @@
 import json
 from pathlib import Path
-from config import LOG_BASE_DIR
+from datetime import datetime
+from config import LOG_BASE_DIR, DECISION_PATH
 
-
-DECISION_PATH = LOG_BASE_DIR / "판단" / "latest_decision.json"
 NEWS_PATH = LOG_BASE_DIR / "뉴스반영" / "latest_news.json"
 
 
@@ -14,6 +13,24 @@ def get_latest_decision() -> dict:
             return json.load(f)
     except Exception:
         return {}
+
+
+def save_decision(action: str, reason: str, human_action: str, score_vs_human, **extra) -> None:
+    """Write a decision entry to ``DECISION_PATH``.
+
+    Additional keyword arguments are merged into the saved JSON data.
+    """
+    decision = {
+        "time": datetime.now().strftime("%Y-%m-%d %H:%M"),
+        "action": action,
+        "reason": reason,
+        "human_likely_action": human_action,
+        "score_vs_human": score_vs_human,
+    }
+    decision.update(extra)
+    Path(DECISION_PATH).parent.mkdir(parents=True, exist_ok=True)
+    with open(DECISION_PATH, "w", encoding="utf-8") as f:
+        json.dump(decision, f, ensure_ascii=False, indent=2)
 
 
 def get_latest_news() -> dict:

--- a/src/config.py
+++ b/src/config.py
@@ -12,6 +12,9 @@ LOG_BASE_DIR = Path(os.environ.get("NOVA_LOG_DIR", r"C:/Users/kanur/log"))
 # status server if present.
 UI_PATH = LOG_BASE_DIR / "UI" / "live_nova_decision_emotion_ui.html"
 
+# Path to the JSON file containing the latest decision
+DECISION_PATH = LOG_BASE_DIR / "판단" / "latest_decision.json"
+
 # Port used by the local Flask status server.  The value may be overridden via
 # the ``LOCAL_SERVER_PORT`` environment variable.
 LOCAL_SERVER_PORT = int(os.environ.get("LOCAL_SERVER_PORT", "5000"))


### PR DESCRIPTION
## Summary
- install `psutil`
- expose `DECISION_PATH` constant in config modules
- add `save_decision` helper in `nova_core`
- open legacy HTML UI on startup
- use `save_decision` in trading loop

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848d147115c8320b7205e7eaef4a103